### PR TITLE
API/Core rewrite: inspect dependencies without yarn|npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  # Include 8.10.0 for npm < 5.7.0 without `npm ci` command.
-  - "8.10.0"
   - "8"
   - "10"
   - "11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changes
 =======
 
+## UNRELEASED
+
+**BREAKING**
+
+* Replace strategy of `yarn|npm install --production` in a temporary directory with better, faster production dependency inference via `inspectdep`.
+* Change the API to take no `custom` options.
+
 ## 0.1.2
 
 * Add better exec support for yarn|npm on windows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We primarily develop in `yarn`, but use `npm` in our benchmarks. Please make sur
 
 * node: `8+`
 * yarn: (anything modern)
-* npm:  `5.7.0+`
+* npm:  (anything modern)
 
 available. Also note that for the time being, our development tools assume a Unix-like environment, which means Mac, Linux, or something like the Windows Subsystem for Linux.
 
@@ -95,8 +95,6 @@ $ yarn benchmark:install
 $ yarn benchmark:build
 
 # Run a benchmark.
-# First, check that `npm` versions is 5.7.0+ (which has `npm ci`).
-$ npm --version
 # Then, actually generate the benchmark.
 # _Note_: Unfortunately, this takes some **time**. Grab a ☕
 $ yarn benchmark

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ As a quick guide to the results table:
     - `simple`: Very small production and development dependencies.
     - `individually`: Same dependencies as `simple`, but with `individually` packaging.
     - `huge`: Lots and lots of development dependencies.
-- `Mode`: Project installed via `yarn` or `npm`?
+- `Mode`: Project installed via `yarn` or `npm`? This really only matters in that `npm` and `yarn` may flatten dependencies differently, so we want to make sure Jetpack is correct in both cases.
 - `Type`: `jetpack` is this plugin and `baseline` is Serverless built-in packaging.
 - `Time`: Elapsed build time in milliseconds.
 - `vs Base`: Percentage difference of `serverless-jetpack` vs. Serverless built-in. Negative values are faster, positive values are slower.
@@ -117,39 +117,23 @@ Machine information:
 
 * os:   `darwin 18.5.0 x64`
 * node: `v8.16.0`
-* yarn: `1.15.2`
-* npm:  `6.4.1`
-
-- TODO: New benchmark file
 
 Results:
 
-| Scenario         | Mode     | Lockfile | Type        |     Time |      vs Base |
-| :--------------- | :------- | :------- | :---------- | -------: | -----------: |
-| **simple**       | **yarn** | **true** | **jetpack** | **4637** | **-32.86 %** |
-| simple           | yarn     | true     | baseline    |     6906 |              |
-| **simple**       | **npm**  | **true** | **jetpack** | **3913** | **-45.20 %** |
-| simple           | npm      | true     | baseline    |     7140 |              |
-| simple           | yarn     | false    | jetpack     |     3512 |     -59.24 % |
-| simple           | yarn     | false    | baseline    |     8616 |              |
-| simple           | npm      | false    | jetpack     |     4188 |     -54.47 % |
-| simple           | npm      | false    | baseline    |     9199 |              |
-| **individually** | **yarn** | **true** | **jetpack** | **3821** | **-79.35 %** |
-| individually     | yarn     | true     | baseline    |    18500 |              |
-| **individually** | **npm**  | **true** | **jetpack** | **5013** | **-71.47 %** |
-| individually     | npm      | true     | baseline    |    17570 |              |
-| individually     | yarn     | false    | jetpack     |     3429 |     -73.50 % |
-| individually     | yarn     | false    | baseline    |    12941 |              |
-| individually     | npm      | false    | jetpack     |     3804 |     -75.35 % |
-| individually     | npm      | false    | baseline    |    15430 |              |
-| **huge**         | **yarn** | **true** | **jetpack** | **6588** | **-79.77 %** |
-| huge             | yarn     | true     | baseline    |    32561 |              |
-| **huge**         | **npm**  | **true** | **jetpack** | **5116** | **-84.71 %** |
-| huge             | npm      | true     | baseline    |    33469 |              |
-| huge             | yarn     | false    | jetpack     |     2242 |     -92.48 % |
-| huge             | yarn     | false    | baseline    |    29829 |              |
-| huge             | npm      | false    | jetpack     |     2431 |     -92.85 % |
-| huge             | npm      | false    | baseline    |    33999 |              |
+| Scenario     | Mode | Type     | Time  |      vs Base |
+| :----------- | :--- | :------- | :---- | -----------: |
+| simple       | yarn | jetpack  | 4338  | **-46.37 %** |
+| simple       | yarn | baseline | 8089  |              |
+| simple       | npm  | jetpack  | 4055  | **-53.78 %** |
+| simple       | npm  | baseline | 8773  |              |
+| individually | yarn | jetpack  | 2964  | **-76.77 %** |
+| individually | yarn | baseline | 12760 |              |
+| individually | npm  | jetpack  | 4183  | **-69.67 %** |
+| individually | npm  | baseline | 13790 |              |
+| huge         | yarn | jetpack  | 4524  | **-84.03 %** |
+| huge         | yarn | baseline | 28321 |              |
+| huge         | npm  | jetpack  | 5680  | **-83.07 %** |
+| huge         | npm  | baseline | 33551 |              |
 
 [Serverless]: https://serverless.com/
 [lerna]: https://lerna.js.org/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ plugins:
 
 ### A little more detail...
 
-The plugin supports all normal built-in Serverless framework packaging configurations. E.g., more complex `serverless.yml` configurations like:
+The plugin supports all normal built-in Serverless framework packaging configurations in `serverless.yml` like:
 
 ```yml
 package:
@@ -66,11 +66,11 @@ functions:
 
 ## How it works
 
-The Serverless framework can be amazingly slow during packaging applications that have lots of files from `devDependencies`. Although the `excludeDevDependencies` option will remove these from the target zip bundle, it does so only **after** the files are read from disk, wasting a lot of disk I/O and time.
+Serverless built-in packaging slows to a crawl in applications that have lots of files from `devDependencies`. Although the `excludeDevDependencies` option will ultimately remove these from the target zip bundle, it does so only **after** the files are read from disk, wasting a lot of disk I/O and time.
 
-The `serverless-jetpack` plugin removes this bottleneck by performing a fast production dependency on-disk discovery via the [inspectdep][] library before any globbing is ddone. The discovered production dependencies are then converted into very efficient patterns that are injected into the otherwise normal Serverless framework packaging heuristics to efficiently avoid all unnecesssary disk I/O due to `devDependencies` in `node_modules`.
+The `serverless-jetpack` plugin removes this bottleneck by performing a fast production dependency on-disk discovery via the [inspectdep][] library before any globbing is done. The discovered production dependencies are then converted into patterns and injected into the otherwise normal Serverless framework packaging heuristics to efficiently avoid all unnecessary disk I/O due to `devDependencies` in `node_modules`.
 
-Process-wise, the `serverless-jetpack` plugin detects when built-in packaging applies and then takes over with a packaging process that mostly mimics what Serverless would do, just faster. The plugin then sets appropriate internal Serverless `artifact` fields to cause Serverless to skip the (slower) built-in packaging.
+Process-wise, the `serverless-jetpack` plugin detects when built-in packaging applies and then takes over the packaging process. The plugin then sets appropriate internal Serverless `artifact` fields to cause Serverless to skip the (slower) built-in packaging.
 
 ### The nitty gritty of why it's faster
 

--- a/README.md
+++ b/README.md
@@ -101,14 +101,13 @@ Jetpack does _most_ of what Serverless does globbing-wise with `include|exclude`
 1. Glob files from disk with a root `**` (all files) and the `include` pattern, following symlinks, and create a list of files.
 2. Apply service + function `exclude`, then `include` patterns in order to decide what is included in the package zip file.
 
-This is potentially slow if `node_modules` contains a lot of ultimately removed files, yielding a lot of completely wasted disk I/O time. Also, following symlinks is expensive, and for `node_modules` almost never useful.
+This is potentially slow if `node_modules` contains a lot of ultimately removed files, yielding a lot of completely wasted disk I/O time.
 
 Jetpack, by contrast does the following:
 
-1. Glob files from disk with a root `**` (all files) and the `include` pattern, **except** for `node_modules` (never read) and without following symlinks to create a list of files.
-2. Apply service + function `exclude`, then `include` patterns in order.
-3. Separately `npm|yarn install` production `node_modules` into a dedicated dependencies build directory. Run the same glob logic and `exclude` + `include` matching over just the new `node_modules`.
-4. Then zip the files from the two separate matching operations.
+1. Efficiently infer production dependencies from disk.
+2. Glob files from disk with a root `**` (all files) that excludes `node_modules` generally from being read except for production dependencies. This small nuance of limiting the `node_modules` globbing to **just** production dependencies gives us an impressive speedup.
+3. Apply service + function `exclude`, then `include` patterns in order to decide what is included in the package zip file.
 
 This _does_ have some other implications like:
 

--- a/README.md
+++ b/README.md
@@ -157,18 +157,18 @@ Machine information:
 Results:
 
 | Scenario     | Mode | Type     | Time  |      vs Base |
-| :----------- | :--- | :------- | :---- | -----------: |
-| simple       | yarn | jetpack  | 4338  | **-46.37 %** |
-| simple       | yarn | baseline | 8089  |              |
-| simple       | npm  | jetpack  | 4055  | **-53.78 %** |
-| simple       | npm  | baseline | 8773  |              |
-| individually | yarn | jetpack  | 2964  | **-76.77 %** |
+| :----------- | :--- | :------- | ----: | -----------: |
+| simple       | yarn | jetpack  |  4338 | **-46.37 %** |
+| simple       | yarn | baseline |  8089 |              |
+| simple       | npm  | jetpack  |  4055 | **-53.78 %** |
+| simple       | npm  | baseline |  8773 |              |
+| individually | yarn | jetpack  |  2964 | **-76.77 %** |
 | individually | yarn | baseline | 12760 |              |
-| individually | npm  | jetpack  | 4183  | **-69.67 %** |
+| individually | npm  | jetpack  |  4183 | **-69.67 %** |
 | individually | npm  | baseline | 13790 |              |
-| huge         | yarn | jetpack  | 4524  | **-84.03 %** |
+| huge         | yarn | jetpack  |  4524 | **-84.03 %** |
 | huge         | yarn | baseline | 28321 |              |
-| huge         | npm  | jetpack  | 5680  | **-83.07 %** |
+| huge         | npm  | jetpack  |  5680 | **-83.07 %** |
 | huge         | npm  | baseline | 33551 |              |
 
 [Serverless]: https://serverless.com/

--- a/README.md
+++ b/README.md
@@ -170,32 +170,32 @@ Machine information:
 
 Results:
 
-| Scenario         | Mode     | Lockfile | Type        |      Time |      vs Base |
-| :--------------- | :------- | :------- | :---------- | --------: | -----------: |
-| **simple**       | **yarn** | **true** | **jetpack** |  **5687** | **-42.16 %** |
-| simple           | yarn     | true     | baseline    |      9832 |              |
-| **simple**       | **npm**  | **true** | **jetpack** |  **6163** | **-31.37 %** |
-| simple           | npm      | true     | baseline    |      8980 |              |
-| simple           | yarn     | false    | jetpack     |      7199 |     -27.73 % |
-| simple           | yarn     | false    | baseline    |      9961 |              |
-| simple           | npm      | false    | jetpack     |     17714 |      50.96 % |
-| simple           | npm      | false    | baseline    |     11734 |              |
-| **individually** | **yarn** | **true** | **jetpack** |  **8259** | **-50.44 %** |
-| individually     | yarn     | true     | baseline    |     16665 |              |
-| **individually** | **npm**  | **true** | **jetpack** |  **9787** | **-50.10 %** |
-| individually     | npm      | true     | baseline    |     19613 |              |
-| individually     | yarn     | false    | jetpack     |      9242 |     -45.27 % |
-| individually     | yarn     | false    | baseline    |     16888 |              |
-| individually     | npm      | false    | jetpack     |     17426 |     -35.68 % |
-| individually     | npm      | false    | baseline    |     27094 |              |
-| **huge**         | **yarn** | **true** | **jetpack** | **13473** | **-71.85 %** |
-| huge             | yarn     | true     | baseline    |     47864 |              |
-| **huge**         | **npm**  | **true** | **jetpack** |  **9451** | **-71.45 %** |
-| huge             | npm      | true     | baseline    |     33105 |              |
-| huge             | yarn     | false    | jetpack     |     15403 |     -38.98 % |
-| huge             | yarn     | false    | baseline    |     25243 |              |
-| huge             | npm      | false    | jetpack     |     25483 |      -9.95 % |
-| huge             | npm      | false    | baseline    |     28300 |              |
+| Scenario         | Mode     | Lockfile | Type        |     Time |      vs Base |
+| :--------------- | :------- | :------- | :---------- | -------: | -----------: |
+| **simple**       | **yarn** | **true** | **jetpack** | **4637** | **-32.86 %** |
+| simple           | yarn     | true     | baseline    |     6906 |              |
+| **simple**       | **npm**  | **true** | **jetpack** | **3913** | **-45.20 %** |
+| simple           | npm      | true     | baseline    |     7140 |              |
+| simple           | yarn     | false    | jetpack     |     3512 |     -59.24 % |
+| simple           | yarn     | false    | baseline    |     8616 |              |
+| simple           | npm      | false    | jetpack     |     4188 |     -54.47 % |
+| simple           | npm      | false    | baseline    |     9199 |              |
+| **individually** | **yarn** | **true** | **jetpack** | **3821** | **-79.35 %** |
+| individually     | yarn     | true     | baseline    |    18500 |              |
+| **individually** | **npm**  | **true** | **jetpack** | **5013** | **-71.47 %** |
+| individually     | npm      | true     | baseline    |    17570 |              |
+| individually     | yarn     | false    | jetpack     |     3429 |     -73.50 % |
+| individually     | yarn     | false    | baseline    |    12941 |              |
+| individually     | npm      | false    | jetpack     |     3804 |     -75.35 % |
+| individually     | npm      | false    | baseline    |    15430 |              |
+| **huge**         | **yarn** | **true** | **jetpack** | **6588** | **-79.77 %** |
+| huge             | yarn     | true     | baseline    |    32561 |              |
+| **huge**         | **npm**  | **true** | **jetpack** | **5116** | **-84.71 %** |
+| huge             | npm      | true     | baseline    |    33469 |              |
+| huge             | yarn     | false    | jetpack     |     2242 |     -92.48 % |
+| huge             | yarn     | false    | baseline    |    29829 |              |
+| huge             | npm      | false    | jetpack     |     2431 |     -92.85 % |
+| huge             | npm      | false    | baseline    |    33999 |              |
 
 [Serverless]: https://serverless.com/
 [lerna]: https://lerna.js.org/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ This _does_ have some other implications like:
 
 ### Complexities
 
-#### Be careful with `include` and `node_modules`
+#### Minor differences vs. Serverless globbing
+
+Our [benchmark correctness tests](./test/benchmark.js) highlight a number of various files not included by Jetpack that are included by `serverless` in packaging our benchmark scenarios. Some of these are things like `node_modules/.yarn-integrity` which Jetpack knowingly ignores because you shouldn't need it. All of the others we've discovered to date are instances in which `serverless` incorrectly includes `devDependencies`...
+
+#### Be careful with `include` configurations and `node_modules`
 
 Jetpack's approach to processing `node_modules` faster than built-in `serverless` packaging hinges on not reading anything in `node_modules` that is not already a production dependencies. It does this by inserting globs like:
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const archiver = require("archiver");
 const globby = require("globby");
 const nanomatch = require("nanomatch");
 // TODO(inspect): need real package.
-const { production } = require("../inspectdep");
+const { findProdInstalls } = require("../inspectdep");
 
 const SLS_TMP_DIR = ".serverless";
 const PLUGIN_NAME = pkg.name;
@@ -302,7 +302,7 @@ class Jetpack {
 
     // Gather files, deps to zip.
     const { include, exclude } = this.filePatterns({ functionObject });
-    const depInclude = await production({ rootPath: servicePath });
+    const depInclude = await findProdInstalls({ rootPath: servicePath });
     const files = await this.resolveFilePathsFromPatterns({ depInclude, include, exclude });
 
     // Create package zip.

--- a/index.js
+++ b/index.js
@@ -83,25 +83,7 @@ class Jetpack {
 
     this.commands = {
       jetpack: {
-        usage: pkg.description,
-        options: {
-          mode: {
-            usage: "Installation mode (default: `yarn`)",
-            shortcut: "m"
-          },
-          lockfile: {
-            usage:
-              "Path to lockfile (default: `yarn.lock` for `mode: yarn`, "
-              + "`package-lock.json` for `mode: npm`)",
-            shortcut: "l"
-          },
-          stdio: {
-            usage:
-              "`child_process` stdio mode for our shell commands like "
-              + "yarn|npm installs (default: `null`)",
-            shortcut: "s"
-          }
-        }
+        usage: pkg.description
       }
     };
 
@@ -119,33 +101,6 @@ class Jetpack {
     if (process.env.SLS_DEBUG) {
       this._log(msg);
     }
-  }
-
-  get _options() {
-    if (this.__options) { return this.__options; }
-
-    const { service } = this.serverless;
-
-    // Static defaults.
-    const defaults = {
-      mode: "yarn",
-      stdio: null
-    };
-
-    const custom = (service.custom || {})[pkg.name];
-    this.__options = Object.assign({}, defaults, custom, this.options);
-
-    // Dynamic defaults
-    if (typeof this.__options.lockfile === "undefined") {
-      this.__options.lockfile = this.__options.mode === "yarn" ? "yarn.lock" : "package-lock.json";
-    }
-
-    // Validation
-    if (!["yarn", "npm"].includes(this.__options.mode)) {
-      throw new Error(`[${pkg.name}] Invalid 'mode' option: ${this.__options.mode}`);
-    }
-
-    return this.__options;
   }
 
   filePatterns({ functionObject }) {

--- a/index.js
+++ b/index.js
@@ -95,16 +95,23 @@ const findDepsFromMap = async ({ map, rootPath, curPath }) => {
 
       // TODO(lists): Insert recursion to find children since it **has** to
       // start from here.
+      //
+      // TODO(lists): The tree looks **wrong**. In that it doesn't represent the entire structure.
+      // Ugh.
+      console.log("TODO HERE", {
+        name,
+        subMap: map[name]
+      });
 
-      return path.relative(rootPath, candidatePath)
+      return path.relative(rootPath, candidatePath);
     }
 
     // TODO(list): Consider a WARN instead and filter out / return null.
-    throw new Error(`Could not resolve location for: ${name}`)
+    throw new Error(`Could not resolve location for: ${name}`);
   }));
 
   return locs;
-}
+};
 
 /**
  * Package Serverless applications manually.
@@ -298,7 +305,7 @@ class Jetpack {
     const map = yarnTreeToMap({ children: list.trees });
     const dirsOnDisk = await findDepsFromMap({ map, rootPath: servicePath });
 
-    console.log("TODO HERE", JSON.stringify({ map, dirsOnDisk }, null, 2));
+    console.log("TODO HERE", JSON.stringify({ map }, null, 2));
 
     return []; // TODO: Get patterns.
   }
@@ -398,7 +405,7 @@ class Jetpack {
     // Gather files, deps to zip.
     const { include, exclude } = this.filePatterns({ functionObject });
     const prodIncludes = await this.getProdDependencyPatterns();
-    console.log("TODO prodIncludes", { prodIncludes });
+    // console.log("TODO prodIncludes", { prodIncludes });
     const files = await this.resolveFilesFromPatterns({ include, exclude });
 
     // Create package zip.

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { createWriteStream } = require("fs");
 const archiver = require("archiver");
 const globby = require("globby");
 const nanomatch = require("nanomatch");
-const { findProdInstalls } = require("inspectdep");
+const { findProdInstalls } = require("../inspectdep");
 
 const SLS_TMP_DIR = ".serverless";
 const PLUGIN_NAME = pkg.name;

--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ class Jetpack {
     });
   }
 
-  async buildAndZip({ bundleName, functionObject }) {
+  async globAndZip({ bundleName, functionObject }) {
     const { config } = this.serverless;
     const servicePath = config.servicePath || ".";
     const bundlePath = path.resolve(servicePath, bundleName);
@@ -273,9 +273,9 @@ class Jetpack {
     // internal copying logic.
     const bundleName = path.join(SLS_TMP_DIR, `${functionName}.zip`);
 
-    // Build.
+    // Package.
     this._log(`Packaging function: ${bundleName}`);
-    await this.buildAndZip({ bundleName, functionObject });
+    await this.globAndZip({ bundleName, functionObject });
 
     // Mutate serverless configuration to use our artifacts.
     functionObject.package = functionObject.package || {};
@@ -290,9 +290,9 @@ class Jetpack {
     // Mimic built-in serverless naming.
     const bundleName = path.join(SLS_TMP_DIR, `${serviceName}.zip`);
 
-    // Build.
+    // Package.
     this._log(`Packaging service: ${bundleName}`);
-    await this.buildAndZip({ bundleName });
+    await this.globAndZip({ bundleName });
 
     // Mutate serverless configuration to use our artifacts.
     servicePackage.artifact = bundleName;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ const { createWriteStream } = require("fs");
 const archiver = require("archiver");
 const globby = require("globby");
 const nanomatch = require("nanomatch");
-// TODO(inspect): need real package.
-const { findProdInstalls } = require("../inspectdep");
+const { findProdInstalls } = require("inspectdep");
 
 const SLS_TMP_DIR = ".serverless";
 const PLUGIN_NAME = pkg.name;

--- a/index.js
+++ b/index.js
@@ -175,6 +175,10 @@ class Jetpack {
 
     // _Now_, start globbing like serverless does.
     // 1. Glob everything on disk using only _includes_ (except `node_modules`).
+    //    This is loosely, what serverless would do with the difference that
+    //    **everything** in `node_modules` is globbed first and then files
+    //    excluded manually by `nanomatch` after. We get the same result here
+    //    without reading from disk.
     const globInclude = ["**"]
       // Remove all node_modules.
       .concat(["!node_modules"])

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { createWriteStream } = require("fs");
 const archiver = require("archiver");
 const globby = require("globby");
 const nanomatch = require("nanomatch");
-const { findProdInstalls } = require("../inspectdep");
+const { findProdInstalls } = require("inspectdep");
 
 const SLS_TMP_DIR = ".serverless";
 const PLUGIN_NAME = pkg.name;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "archiver": "^3.0.0",
     "globby": "^9.2.0",
-    "inspectdep": "^0.1.0",
+    "inspectdep": "^0.1.1",
     "nanomatch": "^1.2.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,11 +37,8 @@
   },
   "dependencies": {
     "archiver": "^3.0.0",
-    "execa": "^1.0.0",
-    "fs-extra": "^7.0.1",
     "globby": "^9.2.0",
-    "nanomatch": "^1.2.13",
-    "uuid": "^3.3.2"
+    "nanomatch": "^1.2.13"
   },
   "devDependencies": {
     "adm-zip": "^0.4.13",
@@ -50,11 +47,13 @@
     "chalk": "^2.4.2",
     "del": "^4.1.1",
     "del-cli": "^1.1.0",
+    "execa": "^1.0.0",
     "eslint": "^5.13.0",
     "eslint-config-formidable": "^4.0.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-promise": "^4.0.1",
+    "fs-extra": "^7.0.1",
     "markdown-table": "^1.1.2",
     "mocha": "^6.1.4",
     "mock-fs": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "archiver": "^3.0.0",
     "globby": "^9.2.0",
-    "inspectdep": "^0.1.1",
+    "inspectdep": "^0.1.2",
     "nanomatch": "^1.2.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "preversion": "yarn run check",
     "usage": "cd test/packages/simple/yarn && MODE=yarn serverless jetpack -h",
-    "clean": "del-cli \"test/packages/*/*/.serverless\"",
+    "clean": "del-cli \"test/packages/*/*/.serverless\" .test-zips",
     "benchmark:install": "node test/script.js install",
     "benchmark:build": "node test/script.js build",
     "benchmark:lint": "eslint \"test/packages/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "archiver": "^3.0.0",
     "globby": "^9.2.0",
+    "inspectdep": "^0.1.0",
     "nanomatch": "^1.2.13"
   },
   "devDependencies": {
@@ -47,12 +48,12 @@
     "chalk": "^2.4.2",
     "del": "^4.1.1",
     "del-cli": "^1.1.0",
-    "execa": "^1.0.0",
     "eslint": "^5.13.0",
     "eslint-config-formidable": "^4.0.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-promise": "^4.0.1",
+    "execa": "^1.0.0",
     "fs-extra": "^7.0.1",
     "markdown-table": "^1.1.2",
     "mocha": "^6.1.4",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -160,7 +160,11 @@ const SLS_FALSE_POSITIVES = {
     // $ yarn why raven -> serverless
     "node_modules/.bin/parser",
     // $ yarn why @cnakazawa/watch -> jest#jest-cli#@jest/core#jest-haste-map#sane
-    "node_modules/.bin/watch"
+    "node_modules/.bin/watch",
+    // $ yarn why sshpk -> cypress#request#http-signature
+    "node_modules/.bin/sshpk-conv",
+    "node_modules/.bin/sshpk-sign",
+    "node_modules/.bin/sshpk-verify"
   ]),
 
   "huge/yarn": new Set([

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -21,12 +21,56 @@ const PKG_IGNORE_ALL = new Set([
   "node_modules/.yarn-integrity"
 ]);
 
+// Windows does poorly with false positives for the basic `serverless` +
+// `serverless-offline` dependencies.
+const SLS_FALSE_POSITIVES_WIN_BASE = [
+  "node_modules/.bin/atob",
+  // yarn why esparse -> esprima serverless#js-yaml
+  "node_modules/.bin/esparse",
+  // yarn why esvalidate -> esprima serverless#js-yaml
+  "node_modules/.bin/esvalidate",
+  // yarn why is-ci -> serverless#update-notifier
+  "node_modules/.bin/is-ci",
+  // yarn why js-yaml -> serverless
+  "node_modules/.bin/js-yaml",
+  // yarn why json-refs -> serverless
+  "node_modules/.bin/json-refs",
+  // yarn why mkdirp -> serverless
+  "node_modules/.bin/mkdirp",
+  // yarn why raven -> serverless
+  "node_modules/.bin/raven",
+  // yarn why rc -> serverless
+  "node_modules/.bin/rc",
+  // yarn why rimraf -> serverless#fs-extra
+  "node_modules/.bin/rimraf",
+  // yarn why seek-bunzip -> seek-bzip serverless#download#decompress#decompress-tarbz2
+  "node_modules/.bin/seek-bunzip",
+  // yarn why seek-table -> seek-bzip serverless#download#decompress#decompress-tarbz2
+  "node_modules/.bin/seek-table",
+  // yarn why semver -> serverless
+  "node_modules/.bin/semver",
+  // yarn why serverless -> devDependencies
+  "node_modules/.bin/serverless",
+  // yarn why sls -> serverless
+  "node_modules/.bin/atslsob",
+  // yarn why slss -> serverless
+  "node_modules/.bin/slss",
+  // yarn why tabtab -> serverless
+  "node_modules/.bin/tabtab",
+  // yarn why velocity -> velocityjs serverless-offline
+  "node_modules/.bin/velocity",
+  // yarn why which -> serverless#update-notifier#boxen#term-size#execa#cross-spawn
+  "node_modules/.bin/which"
+];
+
 // False positives from serverless by scenario.
 // In general, it appears that `serverless` doesn't correctly detect
 // a lot of `jest` dependencies are `devDependencies` when installing with
 // `yarn` (although `npm` looks correct).
 const SLS_FALSE_POSITIVES = {
   "simple/yarn": new Set([
+    ...SLS_FALSE_POSITIVES_WIN_BASE,
+
     // $ yarn why uuid -> serverless
     "node_modules/.bin/uuid",
 
@@ -35,12 +79,24 @@ const SLS_FALSE_POSITIVES = {
     "node_modules/abbrev"
   ]),
 
+  "simple/npm": new Set([
+    ...SLS_FALSE_POSITIVES_WIN_BASE
+  ]),
+
   "individually/yarn": new Set([
+    ...SLS_FALSE_POSITIVES_WIN_BASE,
+
     // $ yarn why uuid -> serverless
     "node_modules/.bin/uuid"
   ]),
 
+  "individually/npm": new Set([
+    ...SLS_FALSE_POSITIVES_WIN_BASE
+  ]),
+
   "huge/npm": new Set([
+    ...SLS_FALSE_POSITIVES_WIN_BASE,
+
     // $ yarn why raven -> serverless
     "node_modules/.bin/parser",
     // $ yarn why @cnakazawa/watch -> jest#jest-cli#@jest/core#jest-haste-map#sane
@@ -48,6 +104,8 @@ const SLS_FALSE_POSITIVES = {
   ]),
 
   "huge/yarn": new Set([
+    ...SLS_FALSE_POSITIVES_WIN_BASE,
+
     // $ yarn why detect-libc -> jest#jest-cli#@jest/core#jest-haste-map#fsevents#node-pre-gyp
     "node_modules/.bin/detect-libc",
     // $ yarn why needle -> jest#jest-cli#@jest/core#jest-haste-map#fsevents#node-pre-gyp

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -52,7 +52,7 @@ const SLS_FALSE_POSITIVES_WIN_BASE = [
   // yarn why serverless -> devDependencies
   "node_modules/.bin/serverless",
   // yarn why sls -> serverless
-  "node_modules/.bin/atslsob",
+  "node_modules/.bin/sls",
   // yarn why slss -> serverless
   "node_modules/.bin/slss",
   // yarn why tabtab -> serverless
@@ -61,6 +61,64 @@ const SLS_FALSE_POSITIVES_WIN_BASE = [
   "node_modules/.bin/velocity",
   // yarn why which -> serverless#update-notifier#boxen#term-size#execa#cross-spawn
   "node_modules/.bin/which"
+];
+
+// ... and the huge scenario has even more false positives
+const SLS_FALSE_POSITIVES_WIN_HUGE = [
+  // yarn why acorn -> next#webpack
+  "node_modules/.bin/acorn",
+  // yarn why amphtml-validator -> next
+  "node_modules/.bin/amphtml-validator",
+  // yarn why ansi-html -> next#webpack-hot-middleware
+  "node_modules/.bin/ansi-html",
+  // yarn why browserslist -> @babel/preset-env
+  "node_modules/.bin/browserslist",
+  // yarn why cypress -> devDependencies
+  "node_modules/.bin/cypress",
+  // yarn why errno -> next#recursive-copy
+  "node_modules/.bin/errno",
+  // yarn why escodegen -> jest#jest-cli#jest-config#jest-environment-jsdom#jsdom
+  "node_modules/.bin/escodegen",
+  // yarn why esgenerate -> escodegen jest#jest-cli#jest-config#jest-environment-jsdom#jsdom
+  "node_modules/.bin/esgenerate",
+  // yarn why extract-zip -> cypress
+  "node_modules/.bin/extract-zip",
+  // yarn why handlebars -> jest#jest-cli#@jest/core#@jest/reporters#istanbul-api#istanbul-reports
+  "node_modules/.bin/handlebars",
+  // yarn why import-local-fixture -> import-local jest
+  "node_modules/.bin/import-local-fixture",
+  // yarn why jest-runtime -> jest#jest-cli#@jest/core
+  "node_modules/.bin/jest-runtime",
+  // yarn why jest -> devDependencies
+  "node_modules/.bin/jest",
+  // yarn why jsesc -> @babel/preset-env...
+  "node_modules/.bin/jsesc",
+  // yarn why json5 -> next#@babel/core
+  "node_modules/.bin/json5",
+  // yarn why miller-rabin -> next#webpack#node-libs-browser#crypto-browserify#diffie-hellman
+  "node_modules/.bin/miller-rabin",
+  // yarn why next -> devDependencies
+  "node_modules/.bin/next",
+  // yarn why regexp-tree -> @babel/preset-env#@babel/plugin-transform-named-capturing-groups-regex
+  "node_modules/.bin/regexp-tree",
+  // yarn why regjsparser -> @babel/preset-env#...
+  "node_modules/.bin/regjsparser",
+  // yarn why sane -> jest#jest-cli#@jest/core#jest-haste-map
+  "node_modules/.bin/sane",
+  // yarn why sha.js -> next#webpack#node-libs-browser#crypto-browserify#create-hash
+  "node_modules/.bin/sha.js",
+  // yarn why terser -> next
+  "node_modules/.bin/terser",
+  // yarn why tsc -> devDependencies
+  "node_modules/.bin/tsc",
+  // yarn why tsserver -> devDependencies
+  "node_modules/.bin/tsserver",
+  // yarn why uglifyjs -> uglify-js jest#jest-cli#@jest/core...
+  "node_modules/.bin/uglifyjs",
+  // yarn why uuid -> cypress#request
+  "node_modules/.bin/uuid",
+  // yarn why webpack -> next
+  "node_modules/.bin/webpack"
 ];
 
 // False positives from serverless by scenario.
@@ -96,6 +154,7 @@ const SLS_FALSE_POSITIVES = {
 
   "huge/npm": new Set([
     ...SLS_FALSE_POSITIVES_WIN_BASE,
+    ...SLS_FALSE_POSITIVES_WIN_HUGE,
 
     // $ yarn why raven -> serverless
     "node_modules/.bin/parser",
@@ -105,6 +164,7 @@ const SLS_FALSE_POSITIVES = {
 
   "huge/yarn": new Set([
     ...SLS_FALSE_POSITIVES_WIN_BASE,
+    ...SLS_FALSE_POSITIVES_WIN_HUGE,
 
     // $ yarn why detect-libc -> jest#jest-cli#@jest/core#jest-haste-map#fsevents#node-pre-gyp
     "node_modules/.bin/detect-libc",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -143,7 +143,7 @@ const keepBaselineMatch = ({ scenario, mode }) => (f) => {
 
   // Exact match for .bin, top-level for everything else.
   return f.startsWith("node_modules/.bin")
-    ? !matches.has(f)
+    ? !matches.has(f.replace(/\.cmd$/, "")) // match unix or windows script
     : !matches.has(topLevel(f));
 };
 

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -24,6 +24,7 @@ const PKG_IGNORE_ALL = new Set([
 // Windows does poorly with false positives for the basic `serverless` +
 // `serverless-offline` dependencies.
 const SLS_FALSE_POSITIVES_WIN_BASE = [
+  // yarn why atob -> jest#jest-cli#@jest/core#micromatch#snapdragon#source-map-resolve
   "node_modules/.bin/atob",
   // yarn why esparse -> esprima serverless#js-yaml
   "node_modules/.bin/esparse",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -120,8 +120,8 @@ describe("benchmark", () => {
     // Create object of `"combo.file = data"
     fixtures = contents.reduce((memo, data, i) => {
       const combo = zipFiles[i].replace(".test-zips/", "").split("/");
-      const key = combo.slice(0, 4).join("/"); // eslint-disable-line no-magic-numbers
-      const file = combo.slice(4); // eslint-disable-line no-magic-numbers
+      const key = combo.slice(0, 3).join("/"); // eslint-disable-line no-magic-numbers
+      const file = combo.slice(3); // eslint-disable-line no-magic-numbers
 
       memo[key] = memo[key] || {};
       memo[key][file] = data;
@@ -130,8 +130,8 @@ describe("benchmark", () => {
     }, {});
   });
 
-  MATRIX.forEach(({ scenario, mode, lockfile }) => {
-    const combo = `${scenario}/${mode}/${lockfile}`;
+  MATRIX.forEach(({ scenario, mode }) => {
+    const combo = `${scenario}/${mode}`;
 
     it(combo, async () => {
       const baselineFixture = fixtures[`${combo}/baseline`];

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -17,8 +17,9 @@ const { MATRIX } = require("./script");
 // throughout installed `node_modules`, but this is tricky to get right and
 // there are known cases of bad matches that we exclude from consideration.
 const PKG_IGNORE_ALL = new Set([
-  // All binaries.
-  "node_modules/.bin"
+  // All binaries and metafiles.
+  "node_modules/.bin",
+  "node_modules/.yarn-integrity"
 ]);
 
 // False positives from serverless by scenario.

--- a/test/packages/huge/npm/serverless.js
+++ b/test/packages/huge/npm/serverless.js
@@ -5,12 +5,6 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 module.exports = {
-  jetpack,
   pkg
 };

--- a/test/packages/huge/npm/serverless.yml
+++ b/test/packages/huge/npm/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
 
 plugins:
   localPath: ../../../plugins

--- a/test/packages/huge/yarn/serverless.js
+++ b/test/packages/huge/yarn/serverless.js
@@ -5,12 +5,6 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 module.exports = {
-  jetpack,
   pkg
 };

--- a/test/packages/huge/yarn/serverless.yml
+++ b/test/packages/huge/yarn/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
 
 plugins:
   localPath: ../../../plugins

--- a/test/packages/individually/npm/serverless.js
+++ b/test/packages/individually/npm/serverless.js
@@ -5,12 +5,6 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 module.exports = {
-  jetpack,
   pkg
 };

--- a/test/packages/individually/npm/serverless.yml
+++ b/test/packages/individually/npm/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
 
 plugins:
   localPath: ../../../plugins

--- a/test/packages/individually/yarn/serverless.js
+++ b/test/packages/individually/yarn/serverless.js
@@ -5,12 +5,6 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 module.exports = {
-  jetpack,
   pkg
 };

--- a/test/packages/individually/yarn/serverless.yml
+++ b/test/packages/individually/yarn/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
 
 plugins:
   localPath: ../../../plugins

--- a/test/packages/simple/npm/serverless.js
+++ b/test/packages/simple/npm/serverless.js
@@ -5,12 +5,6 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 module.exports = {
-  jetpack,
   pkg
 };

--- a/test/packages/simple/npm/serverless.yml
+++ b/test/packages/simple/npm/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
 
 plugins:
   localPath: ../../../plugins

--- a/test/packages/simple/yarn/serverless.js
+++ b/test/packages/simple/yarn/serverless.js
@@ -5,12 +5,6 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 module.exports = {
-  jetpack,
   pkg
 };

--- a/test/packages/simple/yarn/serverless.yml
+++ b/test/packages/simple/yarn/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
 
 plugins:
   localPath: ../../../plugins

--- a/test/packages/webpack/npm/serverless.js
+++ b/test/packages/webpack/npm/serverless.js
@@ -5,17 +5,11 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 const webpack = () => ({
   packager: process.env.MODE
 });
 
 module.exports = {
-  jetpack,
   pkg,
   webpack
 };

--- a/test/packages/webpack/npm/serverless.yml
+++ b/test/packages/webpack/npm/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
   webpack: ${file(./serverless.js):webpack}
 
 plugins:

--- a/test/packages/webpack/yarn/serverless.js
+++ b/test/packages/webpack/yarn/serverless.js
@@ -5,17 +5,11 @@ const pkg = () => ({
   excludeDevDependencies: true
 });
 
-const jetpack = () => ({
-  mode: process.env.MODE,
-  lockfile: process.env.LOCKFILE === "false" ? null : undefined // undefined === default
-});
-
 const webpack = () => ({
   packager: process.env.MODE
 });
 
 module.exports = {
-  jetpack,
   pkg,
   webpack
 };

--- a/test/packages/webpack/yarn/serverless.yml
+++ b/test/packages/webpack/yarn/serverless.yml
@@ -7,7 +7,6 @@ package:
 custom:
   region: ${opt:region, env:AWS_REGION}
   stage: ${opt:stage, env:STAGE}
-  serverless-jetpack: ${file(./serverless.js):jetpack}
   webpack: ${file(./serverless.js):webpack}
 
 plugins:

--- a/test/script.js
+++ b/test/script.js
@@ -61,7 +61,7 @@ const ENV = {
 };
 
 const TABLE_OPTS = {
-  align: ["l", "l", "l", "l", "r", "r"],
+  align: ["l", "l", "l", "r", "r"],
   stringLength: (cell) => strip(cell).length // fix alignment with chalk.
 };
 

--- a/test/spec/glob.spec.js
+++ b/test/spec/glob.spec.js
@@ -22,7 +22,7 @@ const pluginAdapter = async ({ plugin, pkgExclude, pkgInclude, fnExclude, fnIncl
   plugin.serverless.service.package.exclude = pkgExclude;
   plugin.serverless.service.package.include = pkgInclude;
 
-  return await plugin.resolveProjectFilePathsFromPatterns(
+  return await plugin.resolveFilePathsFromPatterns(
     plugin.filePatterns({
       functionObject: {
         "package": {
@@ -77,6 +77,9 @@ describe("globbing (include/exclude) logic", () => {
       expect(pluginError).to.be.ok.and.to.have.property("message", slsError.message);
 
       return pluginError;
+    } else if (pluginError) {
+      // Should **not** have a plugin error alone.
+      throw pluginError;
     }
 
     // Check files.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,6 +1981,11 @@ inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inspectdep@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/inspectdep/-/inspectdep-0.1.0.tgz#1ff4126966bc60683ff1753217d7922c0f5b7a8d"
+  integrity sha512-cDsYtNVCyhS6+YQitqXo+3KLbVwNvjmzhswnLXLU8KAoJh/V6ic7a/NDXQRq+o2vm389/Zi8FsPjqEdlHs/vbA==
+
 invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,7 +4159,7 @@ uuid@3.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
   integrity sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg=
 
-uuid@3.3.2, uuid@^3.3.2:
+uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,10 +1981,10 @@ inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-inspectdep@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/inspectdep/-/inspectdep-0.1.0.tgz#1ff4126966bc60683ff1753217d7922c0f5b7a8d"
-  integrity sha512-cDsYtNVCyhS6+YQitqXo+3KLbVwNvjmzhswnLXLU8KAoJh/V6ic7a/NDXQRq+o2vm389/Zi8FsPjqEdlHs/vbA==
+inspectdep@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/inspectdep/-/inspectdep-0.1.1.tgz#16defe917c7162491728eb03022266d8c486757f"
+  integrity sha512-mu6AjjmCNLVQv2mIg+wTVFKC+Hz+/PqkjXWvfpHbP/06bup0bnU2GCsIk0IjXr0RSIoDMWrYzh6ZeDrnZhL8vA==
 
 invert-kv@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,10 +1981,10 @@ inquirer@^6.2.2:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-inspectdep@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/inspectdep/-/inspectdep-0.1.1.tgz#16defe917c7162491728eb03022266d8c486757f"
-  integrity sha512-mu6AjjmCNLVQv2mIg+wTVFKC+Hz+/PqkjXWvfpHbP/06bup0bnU2GCsIk0IjXr0RSIoDMWrYzh6ZeDrnZhL8vA==
+inspectdep@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/inspectdep/-/inspectdep-0.1.2.tgz#c1de47a0c481aebf91d19e033db10626bf6a7c46"
+  integrity sha512-3frWE9LPlWpRtlu2i1fXEmDC0wfEBCRcA4jqzcwb1i9AgwkCzmHEemFuoSEdTo6B9PM3fCxjgWn9NuEIaat3Wg==
 
 invert-kv@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Tasks
- [x] Experiment with `depInclude` **after** `include`...
    - **Result**: Works for sure, but is a break from `serverless` packaging (e.g., what happens if you have the same configuration and remove Jetpack from plugins).

## Work

* Replace strategy of `yarn|npm install --production` in a temporary directory with better, faster production dependency inference via `inspectdep`.
* Change the API to take no `custom` options.
* Remove `lockfile` option from test / benchmark matrix.

## Faster timings!

| OS      | Scenario     | Type     | Time  |      vs Base |
| :------ | :----------- | :------- | ----: | -----------: |
| Mac     | simple       | jetpack  |  4338 | **-46.37 %** |
| Mac     | simple       | baseline |  8089 |              |
| Mac     | individually | jetpack  |  2964 | **-76.77 %** |
| Mac     | individually | baseline | 12760 |              |
| Mac     | huge         | jetpack  |  4524 | **-84.03 %** |
| Mac     | huge         | baseline | 28321 |              |
| Windows | simple       | jetpack  |  2890 | **-73.88 %** |
| Windows | simple       | baseline | 11063 |              |
| Windows | individually | jetpack  |  3110 | **-83.90 %** |
| Windows | individually | baseline | 19312 |              |
| Windows | huge         | jetpack  |  3500 | **-93.34 %** |
| Windows | huge         | baseline | 52548 |              |