### PR TITLE
add: check if sls directory exists, if not, create it

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const pkg = require("./package.json");
 const path = require("path");
-const { createWriteStream } = require("fs");
+const { createWriteStream, existsSync, mkdirSync } = require("fs");
 const archiver = require("archiver");
 const globby = require("globby");
 const nanomatch = require("nanomatch");
@@ -226,6 +226,12 @@ class Jetpack {
   createZip({ files, filesRoot, bundlePath }) {
     // Use Serverless-analogous library + logic to create zipped artifact.
     const zip = archiver.create("zip");
+    const serverlessDirectory = `${filesRoot}/${SLS_TMP_DIR}`;
+
+    if (!existsSync(serverlessDirectory)) {
+      mkdirSync(serverlessDirectory);
+    }
+
     const output = createWriteStream(bundlePath);
 
     this._logDebug(


### PR DESCRIPTION
Hi thanks for the project,

I'm facing an issue when I run the plugin on projects that already exists.

Run: `sls package --r us-east-1 --s qa`

And got the following error:

`ENOENT: no such file or directory, open '/Users/ndeitch/git/identity/.serverless/identity.zip'`

So I was checking how serverless framework does it, and, as We can [see](https://github.com/serverless/serverless/blob/master/lib/plugins/package/lib/zipService.js#L78) it creates the directory before create zip file.

I implemented it, with a check for directory existence, and locally it works.