### PR TITLE
Add mkdir -p equivalent for bundlePath directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Add a `mkdir -p` equivalent of the directory containing the output bundle same as `serverless` built-in packaging behavior.
+  [#30](https://github.com/FormidableLabs/serverless-jetpack/pull/30)
+  [#31](https://github.com/FormidableLabs/serverless-jetpack/pull/31)
+
 ## 0.2.0
 
 **BREAKING**

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const pkg = require("./package.json");
 const path = require("path");
 const { createWriteStream } = require("fs");
+const makeDir = require("make-dir");
 const archiver = require("archiver");
 const globby = require("globby");
 const nanomatch = require("nanomatch");
@@ -223,9 +224,12 @@ class Jetpack {
     return filtered;
   }
 
-  createZip({ files, filesRoot, bundlePath }) {
+  async createZip({ files, filesRoot, bundlePath }) {
     // Use Serverless-analogous library + logic to create zipped artifact.
     const zip = archiver.create("zip");
+
+    // Ensure full path to bundle exists before opening stream.
+    await makeDir(path.dirname(bundlePath));
     const output = createWriteStream(bundlePath);
 
     this._logDebug(

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "archiver": "^3.0.0",
     "globby": "^9.2.0",
     "inspectdep": "^0.1.2",
+    "make-dir": "^3.0.0",
     "nanomatch": "^1.2.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,6 +2587,13 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
+
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -3537,6 +3544,11 @@ semver-regex@^1.0.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.0.tgz#e95dc415d45ecf03f2f9f83b264a6b11f49c0cca"
+  integrity sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==
 
 serverless@^1.41.1:
   version "1.41.1"


### PR DESCRIPTION
Hat tip to @ndeitch for #30 for noticing that serverless creates the directory path leading up to an output artifact.

This PR supersedes #30 with a few slight differences:

- Use async I/O instead of sync methods
- Just do a one-shot mkdir -p call instead of exists check first.
- Closes #30 