### PR TITLE
Bug/monorepo deps - interleave includes and excludes

### DIFF
--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -422,6 +422,11 @@ describe("benchmark", () => {
       // Now, normalize file lists before comparing.
       yarnFiles = yarnFiles.sort();
 
+      // This diff dependency is expected to **stay** in place because we test
+      // forcing versions to prevent flattening.
+      const NESTED_DIFF = "functions/base/node_modules/diff/";
+
+
       const NPM_NORMS = {
         // Duplicated in yarn.
         // eslint-disable-next-line max-len
@@ -430,14 +435,15 @@ describe("benchmark", () => {
         "functions/base/node_modules/cookie/": "node_modules/express/node_modules/cookie/",
         "functions/base/node_modules/send/node_modules/ms/":
           "node_modules/debug/node_modules/ms/",
-        // Hoist everything to root (which is what yarn should do).
+        // Hoist everything to root (which is what yarn should do), except for
+        // `/diff/` which we've engineered to stay in place...
         "functions/base/node_modules/": "node_modules/",
         "lib/camel/node_modules/": "node_modules/"
       };
       npmFiles = npmFiles
         .map((dep) => {
           for (const norm of Object.keys(NPM_NORMS)) {
-            if (dep.startsWith(norm)) {
+            if (dep.startsWith(norm) && !dep.startsWith(NESTED_DIFF)) {
               return NPM_NORMS[norm] === null ? null : dep.replace(norm, NPM_NORMS[norm]);
             }
           }

--- a/test/packages/monorepo/yarn/serverless.yml
+++ b/test/packages/monorepo/yarn/serverless.yml
@@ -8,7 +8,8 @@ package:
     - "!**/yarn.lock"
     - "!**/package-lock.json"
     # Functions (Use specific function includes)
-    - '!functions' # Not '!functions/**'.
+    - '!functions'
+    - '!functions/**'
 
 custom:
   region: ${opt:region, env:AWS_REGION}

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -169,7 +169,36 @@ describe("util/bundle#resolveFilePathsFromPatterns", () => {
     ]);
   });
 
-  it("doesn't removes appropriate serverless.EXT config file", async () => {
+  it("should handle broad negative include and include re-adding in", async () => {
+    mock({
+      src: {
+        "index.js": "module.exports = 'index'",
+        "foo.js": "module.exports = 'index'",
+        nested: {
+          "index.js": "module.exports = 'index'",
+          nested: {
+            "index.js": "module.exports = 'index'"
+          }
+        }
+      }
+    });
+
+    expect(await compare({
+      pkgInclude: [
+        "!*/**"
+      ],
+      fnInclude: [
+        "src/index.js",
+        "src/nested/**"
+      ]
+    })).to.eql([
+      "src/index.js",
+      "src/nested/index.js",
+      "src/nested/nested/index.js"
+    ]);
+  });
+
+  it("removes appropriate serverless.EXT config file", async () => {
     mock({
       "serverless.js": "",
       "serverless.yml": "",


### PR DESCRIPTION
Attempts to address issue #53 

In order to fix this issue the following changes were made:

- reverse the order of globs so that dependency includes come after service/function-level includes
- adds a test case for `broad negative include with include re-adding in`
- provides the `depInclude` array to `filterFiles` and match depIncludes after matching all service/function includes/excludes

Some stats on the artifacts:
```
// before changes
$ du -sh ./test/packages/monorepo/yarn/.serverless/*
860K    ./test/packages/monorepo/yarn/.serverless/another.zip
696K    ./test/packages/monorepo/yarn/.serverless/base.zip
// after changes
$ du -sh ./test/packages/monorepo/yarn/.serverless/*
860K    ./test/packages/monorepo/yarn/.serverless/another.zip
916K    ./test/packages/monorepo/yarn/.serverless/base.zip
// diff package compressed (the dependency that was missing from the artifact created on master)
$ du -sh ./diff.zip
204K    ./diff.zip
```

# Benchmarks

# Before Changes


## Benchmark: System Information
* os:   `darwin 18.5.0 x64`
* node: `v10.15.0`
* yarn: `1.16.0`
* npm:  `6.4.1`

## Benchmark: Timed Packages
| Scenario     | Mode | Type     |  Time |      vs Base |
| :----------- | :--- | :------- | ----: | -----------: |
| simple       | yarn | jetpack  |  1802 | **-66.08 %** |
| simple       | yarn | baseline |  5312 |              |
| simple       | npm  | jetpack  |  2005 | **-63.47 %** |
| simple       | npm  | baseline |  5488 |              |
| complex      | yarn | jetpack  |  3670 | **-83.22 %** |
| complex      | yarn | baseline | 21875 |              |
| complex      | npm  | jetpack  |  3542 | **-84.23 %** |
| complex      | npm  | baseline | 22467 |              |
| individually | yarn | jetpack  |  2116 | **-72.32 %** |
| individually | yarn | baseline |  7645 |              |
| individually | npm  | jetpack  |  2010 | **-72.93 %** |
| individually | npm  | baseline |  7424 |              |
| huge         | yarn | jetpack  |  2867 | **-85.12 %** |
| huge         | yarn | baseline | 19262 |              |
| huge         | npm  | jetpack  |  3008 | **-85.12 %** |
| huge         | npm  | baseline | 20219 |              |

## Benchmark: Other Packages
| Scenario | Mode | Type     | Time |    vs Base |
| :------- | :--- | :------- | ---: | ---------: |
| monorepo | yarn | jetpack  | 1803 |            |
| monorepo | npm  | jetpack  | 2366 |            |
| webpack  | yarn | jetpack  | 1452 | **3.27 %** |
| webpack  | yarn | baseline | 1406 |            |
| webpack  | npm  | jetpack  | 1605 | **9.86 %** |
| webpack  | npm  | baseline | 1461 |            |

# After Changes

## Benchmark: System Information
* os:   `darwin 18.5.0 x64`
* node: `v10.15.0`
* yarn: `1.16.0`
* npm:  `6.4.1`

## Benchmark: Timed Packages
| Scenario     | Mode | Type     |  Time |      vs Base |
| :----------- | :--- | :------- | ----: | -----------: |
| simple       | yarn | jetpack  |  2042 | **-60.70 %** |
| simple       | yarn | baseline |  5196 |              |
| simple       | npm  | jetpack  |  1806 | **-66.98 %** |
| simple       | npm  | baseline |  5469 |              |
| complex      | yarn | jetpack  |  3623 | **-82.90 %** |
| complex      | yarn | baseline | 21192 |              |
| complex      | npm  | jetpack  |  3627 | **-84.51 %** |
| complex      | npm  | baseline | 23415 |              |
| individually | yarn | jetpack  |  2343 | **-69.33 %** |
| individually | yarn | baseline |  7640 |              |
| individually | npm  | jetpack  |  2094 | **-73.82 %** |
| individually | npm  | baseline |  7997 |              |
| huge         | yarn | jetpack  |  2155 | **-87.85 %** |
| huge         | yarn | baseline | 17732 |              |
| huge         | npm  | jetpack  |  2081 | **-88.76 %** |
| huge         | npm  | baseline | 18514 |              |

## Benchmark: Other Packages
| Scenario | Mode | Type     | Time |      vs Base |
| :------- | :--- | :------- | ---: | -----------: |
| monorepo | yarn | jetpack  | 2543 |              |
| monorepo | npm  | jetpack  | 1946 |              |
| webpack  | yarn | jetpack  | 2000 |  **16.21 %** |
| webpack  | yarn | baseline | 1721 |              |
| webpack  | npm  | jetpack  | 1593 | **-11.99 %** |
| webpack  | npm  | baseline | 1810 |              |


there does not seem to be a statistically significant difference in performance after the changes
