### PR TITLE
Feature: Deterministic build

### DIFF
--- a/util/bundle.js
+++ b/util/bundle.js
@@ -212,6 +212,8 @@ const createZip = async ({ files, cwd, bundlePath }) => {
           //
           // TODO - IDEA: Do a promise queue of reading files in _in order_
           // and then append them as we go, but in a defined order.
+          // - https://github.com/sindresorhus/p-limit
+          // - https://www.npmjs.com/package/p-queue
           zip.file(path.join(cwd, name), {
             name,
             // TODO: HERE -- not enough. Still getting deploys...


### PR DESCRIPTION
## Background

We approximate some built-in `serverless` features to not redeploy on same file contents. With this PR, a second deploy will produce something like:

```
Serverless: [serverless-jetpack] Packaging 0 functions, 1 services, and 2 layers with concurrency 1
Serverless: [serverless-jetpack] Packaged service: .serverless/sls-simple-reference.zip (3.22s)
Serverless: [serverless-jetpack] Packaged layer: .serverless/vendor.zip (0.45s)
Serverless: [serverless-jetpack] Packaged layer: .serverless/repeat.zip (0.01s)
Serverless: Packaging service...
Serverless: Service files not changed. Skipping deployment...
```

Fixes #7 

## Work
- Nuke dates to epoch.
- Add files specifically in sorted order.

@tptee @dmmulroy this will help us along for https://github.com/FormidableLabs/terraform-provider-serverless/issues/10