### PR TITLE
Infra: Rename variables and script logic.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ build: &build
     - run: yarn run check
     - run: yarn test:cli
     # CPUs note: CircleCI reports `36` CPUs while container actually has way less.
-    - run: yarn benchmark --parallel --num-cpus=4
+    - run: yarn benchmark --parallel --concurrency=4
     - run: yarn benchmark:test
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,10 @@ $ TEST_MODE=yarn,npm TEST_SCENARIO=simple yarn benchmark
 # Faster, because scenarios run in parallel, but less reliable results because
 # of impact on your machine. Use this for faster development, but do a normal
 # serial benchmark for pasting results.
+# ... using all CPU cores
 $ yarn benchmark --parallel
+# ... or set the level of concurrency manually
+$ yarn benchmark --concurrency=2
 ```
 
 After this, we can run benchmark specific QA stuff:


### PR DESCRIPTION
- Rename `--num-cpus` to `--concurrency`
- Revise logic of `--parallel` to be "all cores" and `--concurrency` to be "limited" cores.