### PR TITLE
Bugfix: Skip non-Node.js runtimes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 Changes
 =======
 
-## UNRELEASE
+## UNRELEASED
 
+* Bug: Only package Node.js `runtime` service + functions.
+  [#89](https://github.com/FormidableLabs/serverless-jetpack/pull/89)
 * Infra: Add CircleCI.
 
 ## 0.8.1

--- a/index.js
+++ b/index.js
@@ -448,11 +448,10 @@ class Jetpack {
       }));
 
     // Get list of individual functions to package.
-    const fnsPkgsToPackage = fnsPkgs.filter((obj) =>
-      // Individually packaged
-      (servicePackage.individually || obj.individually)
+    const individualPkgs = fnsPkgs.filter((obj) => servicePackage.individually || obj.individually);
+    const fnsPkgsToPackage = individualPkgs.filter((obj) =>
       // Enabled
-      && !(obj.disable || obj.artifact)
+      !(obj.disable || obj.artifact)
       // Function runtime is node or unspecified + service-level node.
       && (obj.isNode || !obj.runtime && serviceIsNode)
     );
@@ -460,6 +459,9 @@ class Jetpack {
     tasks = tasks.concat(fnsPkgsToPackage.map((obj) => () =>
       this.packageFunction({ ...obj, worker, report })
     ));
+    if (numFns < individualPkgs.length) {
+      this._log(`Skipping individual packaging for ${individualPkgs.length - numFns} functions`);
+    }
 
     // We recreate the logic from `packager#packageService` for deciding whether
     // to package the service or not.

--- a/test/packages/individually/npm/handler.py
+++ b/test/packages/individually/npm/handler.py
@@ -1,0 +1,9 @@
+import json
+
+def hello(event, context):
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+          "message": "Hello!"
+      })
+    }

--- a/test/packages/individually/npm/serverless.yml
+++ b/test/packages/individually/npm/serverless.yml
@@ -29,6 +29,7 @@ functions:
     events: # Use a generic proxy to allow Express app to route.
       - http: ANY /base
       - http: 'ANY /base/{proxy+}'
+
   another:
     handler: src/another.handler
     events:
@@ -54,3 +55,14 @@ functions:
         # Re-exclude
         - "!**/node_modules/**/LICENSE"
         - "package.json"
+
+  # Python-only handler.
+  python:
+    handler: handler.hello
+    runtime: python3.7
+    package:
+      include:
+        - "!**/node_modules/**"
+        - "!**/*.js"
+        - "!**/*.lock"
+        - "*.py"

--- a/test/packages/individually/yarn/handler.py
+++ b/test/packages/individually/yarn/handler.py
@@ -1,0 +1,9 @@
+import json
+
+def hello(event, context):
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+          "message": "Hello!"
+      })
+    }

--- a/test/packages/individually/yarn/handler.py
+++ b/test/packages/individually/yarn/handler.py
@@ -5,5 +5,5 @@ def hello(event, context):
         "statusCode": 200,
         "body": json.dumps({
           "message": "Hello!"
-      })
+        })
     }

--- a/test/packages/individually/yarn/serverless.yml
+++ b/test/packages/individually/yarn/serverless.yml
@@ -29,6 +29,7 @@ functions:
     events: # Use a generic proxy to allow Express app to route.
       - http: ANY /base
       - http: 'ANY /base/{proxy+}'
+
   another:
     handler: src/another.handler
     events:
@@ -54,3 +55,14 @@ functions:
         # Re-exclude
         - "!**/node_modules/**/LICENSE"
         - "package.json"
+
+  # Python-only handler.
+  python:
+    handler: handler.hello
+    runtime: python3.7
+    package:
+      include:
+        - "!**/node_modules/**"
+        - "!**/*.js"
+        - "!**/*.lock"
+        - "*.py"

--- a/test/script.js
+++ b/test/script.js
@@ -99,6 +99,7 @@ const build = async () => {
     "serverless.*",
     "src/**",
     "*.js",
+    "*.py",
     "functions/*/src/**",
     "functions/*/package.json",
     "layers/*/*.js",


### PR DESCRIPTION
This builds on @thejuan 's work in #90 and supersedes it. Fixes #89 

- Use package ignore logic from #90 
- Add service-level ignore
- Add test fixture for individually scenario

@thejuan -- Can you review and kick the tires on this if it looks good to you?

As a side note, for the individually fixture, I did the following config:

```yml
  python:
    handler: handler.hello
    runtime: python3.7
    package:
      include:
        - "!**/node_modules/**"
        - "!**/*.js"
        - "!**/*.lock"
        - "*.py"
```

And I ended up with just the following in the output zip for both jetpack and built-in native serverless packaging:

```sh
$ unzip -Z1 .test-zips/individually/yarn/jetpack/python.zip 
handler.py
package.json
```
