### PR TITLE
Feature: tracing allowMissing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Add `jetpack.trace.allowMissing` configuration option.
+
 ## 0.10.0
 
 * Add dependency tracing feature and `jetpack.trace` configuration options.

--- a/README.md
+++ b/README.md
@@ -417,6 +417,11 @@ functions:
         # When individually, `ignores` from fn are added: `["aws-sdk", "react-ssr-prepass"]`
         ignores:
           - "react-ssr-prepass"
+        # When individually, `allowMissing` smart merges like:
+        # `{ "ws": ["bufferutil", "utf-8-validate", "another"] }`
+        allowMissing:
+          "ws":
+            - "another"
 
   # Individually with explicit `false` will not be traced
   individually-packaged-1:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "make-dir": "^3.0.2",
     "nanomatch": "^1.2.13",
     "p-limit": "^2.2.2",
-    "trace-deps": "^0.2.0"
+    "trace-deps": "FormidableLabs/trace-deps#feature/acceptable-import-failures"
   },
   "devDependencies": {
     "adm-zip": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "make-dir": "^3.0.2",
     "nanomatch": "^1.2.13",
     "p-limit": "^2.2.2",
-    "trace-deps": "FormidableLabs/trace-deps#feature/acceptable-import-failures"
+    "trace-deps": "^0.2.3"
   },
   "devDependencies": {
     "adm-zip": "^0.4.14",

--- a/test/cli/package.spec.js
+++ b/test/cli/package.spec.js
@@ -129,7 +129,7 @@ describe("jetpack package", function () {
     });
 
     it("packages all functions with no options", async () => {
-      const { stdout } = await sls(["jetpack", "package"], { cwd });
+      const { stdout } = await sls(["jetpack", "package", "--report"], { cwd });
       expect(stdout)
         .to.contain(`Packaged service (dependency mode): ${SERVICE_PKG}`).and
         .to.contain(`Packaged function (dependency mode): ${INDIVIDUALLY_PKG}`).and
@@ -142,7 +142,7 @@ describe("jetpack package", function () {
 
     it("packages all functions with no options in trace mode", async () => {
       mode = "trace";
-      const { stdout } = await sls(["jetpack", "package"], { cwd });
+      const { stdout } = await sls(["jetpack", "package", "--report"], { cwd });
       expect(stdout)
         .to.contain(`Packaged service (trace mode): ${SERVICE_PKG}`).and
         .to.contain(`Packaged function (trace mode): ${INDIVIDUALLY_PKG}`).and

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -273,7 +273,7 @@ const createZip = async ({ files, cwd, bundlePath }) => {
  * @param {string}    opts.base         optional base directory (relative to `servicePath`)
  * @param {string[]}  opts.roots        optional dependency roots (relative to `servicePath`)
  * @param {string}    opts.bundleName   output bundle name
- * @param {string[]}  opts.traceIgnores package paths to ignore in tracing mode
+ * @param {object}    opts.traceParams  `trace-deps` options (ignores, allowMissing, ...)
  * @param {string[]}  opts.preInclude   glob patterns to include first
  * @param {string[]}  opts.traceInclude glob patterns from tracing mode
  * @param {string[]}  opts.include      glob patterns to include
@@ -288,7 +288,7 @@ const globAndZip = async ({
   base,
   roots,
   bundleName,
-  traceIgnores,
+  traceParams = {},
   preInclude,
   traceInclude,
   include,
@@ -310,7 +310,7 @@ const globAndZip = async ({
     // [Trace Mode] Trace and introspect all individual dependency files.
     // Add them as _patterns_ so that later globbing exclusions can apply.
     const srcPaths = await globby(traceInclude, { cwd });
-    const traced = await traceFiles({ srcPaths, ignores: traceIgnores });
+    const traced = await traceFiles({ ...traceParams, srcPaths });
 
     // Aggregate.
     depInclude = depInclude.concat(
@@ -351,7 +351,8 @@ const globAndZip = async ({
       ...results,
       roots,
       trace: {
-        ignores: traceIgnores || []
+        ignores: traceParams.ignores || [],
+        allowMissing: traceParams.allowMissing || {}
       },
       patterns: {
         preInclude,

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,10 +363,10 @@ acorn-jsx@^5.1.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
   integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
-acorn-node@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
-  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
+acorn-node@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-2.0.0.tgz#166fdcbd5aeb3f1957a05c699911a26a9f5592c0"
+  integrity sha512-BKPICDOEXUF/q/ltRrXLW7QGi+06r68BSQr4BNFZnY8L04KsYRttFq7SDsCdBEwfuGVdBV9AgaQtUkAbHg5Qnw==
   dependencies:
     acorn "^7.0.0"
     acorn-walk "^7.0.0"
@@ -5266,12 +5266,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-trace-deps@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.2.0.tgz#18d3ea1c4c084f214d783ced13de92efda394f6f"
-  integrity sha512-xAFJN6xqjYZFMLqjwosXQnyOTFSuA7g7aysUTPPLxGUl2jE0N5DvcSrjJABXyrCEyo3tP8o26J4Ejr1B1e0RDg==
+trace-deps@FormidableLabs/trace-deps#feature/acceptable-import-failures:
+  version "0.2.2"
+  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/a7fedff022d0a4217a0001d0f361b8f2f394a745"
   dependencies:
-    acorn-node "^1.8.2"
+    acorn-node "^2.0.0"
     resolve "^1.15.1"
 
 traverse@^0.6.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5266,9 +5266,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-trace-deps@FormidableLabs/trace-deps#feature/acceptable-import-failures:
-  version "0.2.2"
-  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/a7fedff022d0a4217a0001d0f361b8f2f394a745"
+trace-deps@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.2.3.tgz#8ce07f0550fe9db24b5de5681be51a1d646f8da0"
+  integrity sha512-6XizL+QbayR2vC/9O49DErvNel6pheAIylbGYrB/+TIu9uznokHN1gkCSM5kjl2X8xsD9QgN00xb8jUMc/Ne8g==
   dependencies:
     acorn-node "^2.0.0"
     resolve "^1.15.1"


### PR DESCRIPTION
## Work
- Add `jetpack.trace.allowMissing` configuration option.
- Internally switch to `traceParams` to pass around arbitrary `trace-deps` options.

## Tasks
- [x] Update to published `trace-deps` when https://github.com/FormidableLabs/trace-deps/pull/23 merges

/cc @aisapatino 