### PR TITLE
Feature: Detect, log, optionally bail on collapsed zip file conflicts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: Detect and issue warnings for collapsed files in package.
+  [#109](https://github.com/FormidableLabs/serverless-jetpack/pull/109)
+
 ## 0.10.1
 
 * Add `jetpack.trace.allowMissing` configuration option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes
 
 ## UNRELEASED
 
-* Feature: Detect and issue warnings for collapsed files in package.
+* Feature: Detect and issue warnings for collapsed files in package. Add `jetpack.collapsed.bail` option to kill serverless on detected conflicts.
   [#109](https://github.com/FormidableLabs/serverless-jetpack/pull/109)
 
 ## 0.10.1

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ Most Serverless framework projects should be able to use Jetpack without any ext
 * `preInclude` (`Array<string>`): A list of glob patterns to be added _before_ Jetpack's dependency pattern inclusion and Serverless' built-in service-level and then function-level `package.include`s. This option most typically comes up in a monorepo scenario where you want a broad base exclusion like `!functions/**` or `!packages/**` at the service level and then inclusions in later functions.
 * `concurrency` (`Number`): The number of independent package tasks (per function and service) to run off the main execution thread. If `1`, then run tasks serially in main thread. If `2+` run off main thread with `concurrency` number of workers. (default: `1`).
     * This option is most useful for Serverless projects that (1) have many individually packaged functions, and (2) large numbers of files and dependencies. E.g., start considering this option if your per-function packaging time takes more than 10 seconds and you have more than one service and/or function package.
+* `collapsed.bail` (`Boolean`): Terminate `serverless` program with an error if collapsed file conflicts are detected. See [discussion below](#packaging-files-outside-cwd) regarding collapsed files.
 
 The following **function** and **layer**-level configurations available via `functions.{FN_NAME}.jetpack` and  `layers.{LAYER_NAME}.jetpack`:
 
 * `roots` (`Array<string>`): This option **adds** more dependency roots to the service-level `roots` option.
 * `preInclude` (`Array<string>`): This option **adds** more glob patterns to the service-level `preInclude` option.
+* `collapsed.bail` (`Boolean`): Terminate `serverless` program with an error if collapsed file conflicts are detected **if** the function is being packaged `individually`.
 
 Here are some example configurations:
 
@@ -366,7 +368,7 @@ this will append files with the same path in the zip file:
 
 that when expanded leave only **one** file actually on disk!
 
-##### How to Solve Zipping Problems
+##### How to Detect Zipping Problems
 
 The first level is _detecting_ potentially collapsed files that conflict. Jetpack does this automatically with log warnings like:
 
@@ -377,6 +379,10 @@ Serverless: [serverless-jetpack] .serverless/graphql.zip collapsed files:
 ```
 
 In the above example, two different versions of lodash were installed and their files were collapsed into the same path space. A total of 216 files will end up collapsed into 108 when expanded on disk in your cloud function. Yikes!
+
+A good practice if you are using tracing mode is to set: `jetpack.collapsed.bail = true` so that Jetpack will throw an error and kill the `serverless` program if any collapsed conflicts are detected.
+
+##### How to Solve Zipping Problems
 
 So how do we fix the problem?
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,9 @@ Serverless: [serverless-jetpack] .serverless/graphql.zip collapsed files:
 - lodash (108 unique, 216 total): [node_modules/lodash@4.17.11, ../node_modules/lodash@4.17.15]
 ```
 
-In the above example, two different versions of lodash were installed and their files were collapsed into the same path space. So how do we fix the problem?
+In the above example, two different versions of lodash were installed and their files were collapsed into the same path space. A total of 216 files will end up collapsed into 108 when expanded on disk in your cloud function. Yikes!
+
+So how do we fix the problem?
 
 A first starting point is to generate a full report of the packaging step. Instead of running `serverless deploy|package <OPTIONS>`, try out `serverless jetpack package --report <OPTIONS>`. This will produce a report at the end of packaging that gives a full list of files. You can then use the logged message above as a starting point to examine the actual files collapsed in the zip file. Then, spend a little time figuring out the dependencies of how things ended up where.
 
@@ -391,7 +393,7 @@ With a better understanding of what the files are and why we can turn to avoidin
     ```
 
     with `serverless` being run from `backend` as CWD then `ROOT/node_modules` and `ROOT/backend/node_modules` will present potential collapsing conflicts. So, if possible, just remove the `backend/package.json` dependencies and stick them all either in the root or further nested into the functions/packages of the monorepo.
-* **Mirror exact same dependencies in `package.json`s**: In our above example, even if `lodash` isn't declared in either `../package.json` or `package.json` we can manually add it to both at the same pinned version (e.g., `"lodash": "4.17.15") to force it to be the same no matter where npm or Yarn place the dependency on disk.
+* **Mirror exact same dependencies in `package.json`s**: In our above example, even if `lodash` isn't declared in either `../package.json` or `package.json` we can manually add it to both at the same pinned version (e.g., `"lodash": "4.17.15"`) to force it to be the same no matter where npm or Yarn place the dependency on disk.
 * **Use Yarn Resolutions**: If you are using Yarn and [resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/) are an option that works for your project, they are a straightforward way to ensure that only one of a dependency exists on disk, solving collapsing problems.
 
 ## Tracing Mode

--- a/README.md
+++ b/README.md
@@ -393,8 +393,12 @@ With a better understanding of what the files are and why we can turn to avoidin
     ```
 
     with `serverless` being run from `backend` as CWD then `ROOT/node_modules` and `ROOT/backend/node_modules` will present potential collapsing conflicts. So, if possible, just remove the `backend/package.json` dependencies and stick them all either in the root or further nested into the functions/packages of the monorepo.
+
 * **Mirror exact same dependencies in `package.json`s**: In our above example, even if `lodash` isn't declared in either `../package.json` or `package.json` we can manually add it to both at the same pinned version (e.g., `"lodash": "4.17.15"`) to force it to be the same no matter where npm or Yarn place the dependency on disk.
+
 * **Use Yarn Resolutions**: If you are using Yarn and [resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/) are an option that works for your project, they are a straightforward way to ensure that only one of a dependency exists on disk, solving collapsing problems.
+
+* **Use `package.include|exclude`**: You can manually adjust packaging by excluding files that would be collapsed and then allowing the other ones to come into play. In our example above, a negative `package.include` for `!node_modules/lodash/**` would solve our problem in a semver-acceptable way by leaving only root-level lodash.
 
 ## Tracing Mode
 

--- a/index.js
+++ b/index.js
@@ -142,9 +142,9 @@ class Jetpack {
     };
   }
 
-  _log(msg) {
+  _log(msg, opts) {
     const { cli } = this.serverless;
-    cli.log(`[${PLUGIN_NAME}] ${msg}`);
+    cli.log(`[${PLUGIN_NAME}] ${msg}`, null, opts);
   }
 
   _logDebug(msg) {
@@ -155,7 +155,7 @@ class Jetpack {
 
   _logWarning(msg) {
     const { cli } = this.serverless;
-    cli.log(`[${PLUGIN_NAME}][WARNING] ${msg}`, null, { color: "red" });
+    cli.log(`[${PLUGIN_NAME}] WARNING: ${msg}`, null, { color: "red" });
   }
 
   // Root options.
@@ -360,30 +360,31 @@ class Jetpack {
 
   // Handle collapsed duplicates.
   _handleCollapsed({ collapsed, bundleName }) {
-    const haveSrcs = !!Object.keys(collapsed.srcs).length;
-    const havePkgs = !!Object.keys(collapsed.pkgs).length;
+    const srcsLen = Object.keys(collapsed.srcs).length;
+    const pkgsLen = Object.keys(collapsed.pkgs).length;
 
     // Nothing collapsed. Yay!
-    if (!haveSrcs && !havePkgs) { return; }
+    if (!srcsLen && !pkgsLen) { return; }
 
-    if (haveSrcs) {
+    if (srcsLen) {
       console.log("TODO IMPLEMENT");
     }
 
-    if (havePkgs) {
+    if (pkgsLen) {
       const pkgReport = Object.entries(collapsed.pkgs)
-        .map(([group, { packages, numUniquePaths, numTotalFiles }]) => [
-          `${group} (${numUniquePaths} unique, ${numTotalFiles} total): [${
-            Object.values(packages).map((obj) => `${obj.path}@${obj.version}`).join(",")
+        .map(([group, { packages, numUniquePaths, numTotalFiles }]) =>
+          `- ${group} (${numUniquePaths} unique, ${numTotalFiles} total): [${
+            Object.values(packages).map((obj) => `${obj.path}@${obj.version}`).join(", ")
           }]`
-        ])
-        .join(",");
+        )
+        .join("\n");
 
       this._logWarning(
-        `Found collapsed dependencies in ${bundleName}: ${pkgReport}. `
-        + "Please see report (`jetpack package --report`) and fix collapsed files. "
-        + "See: TODO_LINK"
+        `Found ${pkgsLen} collapsed dependencies in ${bundleName}! `
+        + "Please fix, with hints at: "
+        + "https://npm.im/serverless-jetpack#packaging-files-outside-cwd"
       );
+      this._log(`${bundleName} collapsed files:\n${pkgReport}`, { color: "gray" });
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -367,7 +367,18 @@ class Jetpack {
     if (!srcsLen && !pkgsLen) { return; }
 
     if (srcsLen) {
-      console.log("TODO IMPLEMENT");
+      const srcsReport = Object.entries(collapsed.srcs)
+        .map(([group, { numUniquePaths, numTotalFiles }]) =>
+          `- ${group} (${numUniquePaths} unique, ${numTotalFiles} total)`
+        )
+        .join("\n");
+
+      this._logWarning(
+        `Found ${srcsLen} collapsed source files in ${bundleName}! `
+        + "Please fix, with hints at: "
+        + "https://npm.im/serverless-jetpack#packaging-files-outside-cwd"
+      );
+      this._log(`${bundleName} collapsed source files:\n${srcsReport}`, { color: "gray" });
     }
 
     if (pkgsLen) {
@@ -384,7 +395,7 @@ class Jetpack {
         + "Please fix, with hints at: "
         + "https://npm.im/serverless-jetpack#packaging-files-outside-cwd"
       );
-      this._log(`${bundleName} collapsed files:\n${pkgReport}`, { color: "gray" });
+      this._log(`${bundleName} collapsed dependencies:\n${pkgReport}`, { color: "gray" });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "adm-zip": "^0.4.14",
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "chalk": "^4.0.0",
     "del": "^5.1.0",
     "del-cli": "^3.0.0",

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,6 +2,9 @@
 
 const { expect, use } = require("chai");
 const sinonChai = require("sinon-chai");
+const chaiAsPromised = require("chai-as-promised");
 
 use(sinonChai);
+use(chaiAsPromised);
+
 global.expect = expect;

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -473,7 +473,8 @@ describe("index", () => {
       beforeEach(() => {
         // Don't actually read disk and bundle.
         sandbox.stub(Jetpack.prototype, "globAndZip").returns(Promise.resolve({
-          buildTime: 0
+          buildTime: 0,
+          collapsed: { srcs: {}, pkgs: {} }
         }));
       });
 

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -5,10 +5,14 @@
  * include globbing logic of serverless.
  */
 
+const path = require("path");
 const mock = require("mock-fs");
 
 const Jetpack = require("../../..");
-const { resolveFilePathsFromPatterns } = require("../../../util/bundle");
+const {
+  findCollapsed,
+  resolveFilePathsFromPatterns
+} = require("../../../util/bundle");
 const packageService = require("serverless/lib/plugins/package/lib/packageService");
 
 // Serverless mixes in the function, so we do for a mock.
@@ -52,141 +56,238 @@ const slsAdapter = async ({ sls, pkgExclude, pkgInclude, fnExclude, fnInclude })
   });
 };
 
-describe("util/bundle#resolveFilePathsFromPatterns", () => {
-  let plugin;
-  let sls;
-
-  // Bridge to compare equality between jetpack and serverless.
-  // eslint-disable-next-line max-statements
-  const compare = async ({ pkgExclude, pkgInclude, fnExclude, fnInclude }) => {
-    let pluginFiles;
-    let pluginError;
-
-    try {
-      pluginFiles = await pluginAdapter({ plugin, pkgExclude, pkgInclude, fnExclude, fnInclude });
-    } catch (pluginErr) {
-      pluginError = pluginErr;
-    }
-
-    let slsFiles;
-    let slsError;
-    try {
-      slsFiles = await slsAdapter({ sls, pkgExclude, pkgInclude, fnExclude, fnInclude });
-    } catch (slsErr) {
-      slsError = slsErr;
-    }
-
-    // Check errors.
-    if (slsError) {
-      expect(slsError).to.be.ok.and.to.have.property("message");
-      expect(pluginError).to.be.ok.and.to.have.property("message", slsError.message);
-
-      return pluginError;
-    } else if (pluginError) {
-      // Should **not** have a plugin error alone.
-      throw pluginError;
-    }
-
-    // Check files.
-    expect(pluginFiles).to.eql(slsFiles);
-
-    return pluginFiles;
-  };
-
+describe("util/bundle", () => {
   beforeEach(() => {
     mock({});
-
-    const slsBase = {
-      config: {
-        servicePath: ""
-      },
-      processedInput: {
-        options: {}
-      },
-      classes: {
-        Error
-      },
-      pluginManager: {
-        parsePluginsObject: () => ({})
-      },
-      service: {
-        "package": {
-          exclude: [],
-          include: []
-        },
-        getAllLayers: () => []
-      }
-    };
-
-    plugin = new Jetpack(slsBase);
-    sls = new Sls(slsBase);
   });
 
   afterEach(() => {
     mock.restore();
   });
 
-  it("should error on no patterns, no matches", async () => {
-    expect(await compare({}))
-      .to.be.an("Error").and
-      .to.have.property("message", "No file matches include / exclude patterns");
-  });
-
-  it("should match on no patterns, basic sources", async () => {
-    mock({
-      src: {
-        "index.js": "module.exports = 'foo';"
-      }
+  describe("#findCollapsed", () => {
+    it("should handle empty cases", async () => {
+      expect(await findCollapsed({ files: [] })).to.eql({
+        srcs: {},
+        pkgs: {}
+      });
     });
 
-    expect(await compare({})).to.eql([
-      "src/index.js"
-    ]);
-  });
+    it("should handle no duplicates", async () => {
+      const files = [
+        "src/server/index.js",
+        "src/server/dates.js",
+        "node_modules/lodash/index.js",
+        "node_modules/lodash/package.json",
+        "../node_modules/up-a-level/index.js",
+        "../node_modules/up-a-level/package.json"
+      ];
 
-  it("should handle broad exclude and include re-adding in", async () => {
-    mock({
-      src: {
-        "index.js": "module.exports = 'index';",
-        "bar.js": "module.exports = 'bar';",
-        "baz.js": "module.exports = 'baz';",
-        stuff: {
-          "what.css": "what",
-          "what.svg": "what"
+      expect(await findCollapsed({ files })).to.eql({
+        srcs: {},
+        pkgs: {}
+      });
+    });
+
+    it("should find collapsed packages", async () => {
+      /* eslint-disable camelcase */
+      mock({
+        level1: {
+          level2: {
+            node_modules: {
+              smooshed: {
+                "package.json": JSON.stringify({ version: "3.0.0" })
+              }
+            }
+          },
+          node_modules: {
+            smooshed: {
+              "package.json": JSON.stringify({ version: "2.0.0" })
+            }
+          }
+        },
+        node_modules: {
+          smooshed: {
+            "package.json": JSON.stringify({ version: "1.0.0" })
+          }
         }
-      }
+      });
+      /* eslint-enable camelcase */
+
+      const files = [
+        "src/server/index.js",
+        "src/server/dates.js",
+        "node_modules/lodash/index.js",
+        "node_modules/lodash/package.json",
+        "node_modules/smooshed/index.js",
+        "node_modules/smooshed/package.json",
+        "../node_modules/smooshed/index.js",
+        "../node_modules/smooshed/package.json",
+        "../../node_modules/smooshed/index.js",
+        "../../node_modules/smooshed/package.json"
+      ];
+
+      const cwd = path.resolve("level1/level2");
+
+      expect(await findCollapsed({ files, cwd })).to.eql({
+        srcs: {},
+        pkgs: {
+          "node_modules/smooshed": {
+            numTotalFiles: 6,
+            numUniquePaths: 2,
+            packages: [
+              {
+                path: "node_modules/smooshed/package.json",
+                version: "3.0.0"
+              },
+              {
+                path: "../node_modules/smooshed/package.json",
+                version: "2.0.0"
+              },
+              {
+                path: "../../node_modules/smooshed/package.json",
+                version: "1.0.0"
+              }
+            ]
+          }
+        }
+      });
     });
 
-    expect(await compare({
-      pkgExclude: [
-        "**/b*.js",
-        "**/*.svg"
-      ],
-      pkgInclude: [
-        "src/bar.js"
-      ]
-    })).to.eql([
-      "src/bar.js",
-      "src/index.js",
-      "src/stuff/what.css"
-    ]);
+    it("should handle missing package.json in collapsed packages"); // TODO
+    it("should find collapsed sources"); // TODO
   });
 
-  it("doesn't removes appropriate serverless.EXT config file", async () => {
-    mock({
-      "serverless.js": "",
-      "serverless.yml": "",
-      src: {
-        "index.js": "module.exports = 'index';"
+  describe("#resolveFilePathsFromPatterns", () => {
+    let plugin;
+    let sls;
+
+    // Bridge to compare equality between jetpack and serverless.
+    // eslint-disable-next-line max-statements
+    const compare = async ({ pkgExclude, pkgInclude, fnExclude, fnInclude }) => {
+      let pluginFiles;
+      let pluginError;
+
+      try {
+        pluginFiles = await pluginAdapter({ plugin, pkgExclude, pkgInclude, fnExclude, fnInclude });
+      } catch (pluginErr) {
+        pluginError = pluginErr;
       }
+
+      let slsFiles;
+      let slsError;
+      try {
+        slsFiles = await slsAdapter({ sls, pkgExclude, pkgInclude, fnExclude, fnInclude });
+      } catch (slsErr) {
+        slsError = slsErr;
+      }
+
+      // Check errors.
+      if (slsError) {
+        expect(slsError).to.be.ok.and.to.have.property("message");
+        expect(pluginError).to.be.ok.and.to.have.property("message", slsError.message);
+
+        return pluginError;
+      } else if (pluginError) {
+        // Should **not** have a plugin error alone.
+        throw pluginError;
+      }
+
+      // Check files.
+      expect(pluginFiles).to.eql(slsFiles);
+
+      return pluginFiles;
+    };
+
+    beforeEach(() => {
+      const slsBase = {
+        config: {
+          servicePath: ""
+        },
+        processedInput: {
+          options: {}
+        },
+        classes: {
+          Error
+        },
+        pluginManager: {
+          parsePluginsObject: () => ({})
+        },
+        service: {
+          "package": {
+            exclude: [],
+            include: []
+          },
+          getAllLayers: () => []
+        }
+      };
+
+      plugin = new Jetpack(slsBase);
+      sls = new Sls(slsBase);
     });
 
-    expect(await compare({})).to.eql([
-      "serverless.js",
-      "src/index.js"
-    ]);
-  });
+    it("should error on no patterns, no matches", async () => {
+      expect(await compare({}))
+        .to.be.an("Error").and
+        .to.have.property("message", "No file matches include / exclude patterns");
+    });
 
-  it("should handle only node_modules"); // TODO(10)
-  it("should handle sources and node_modules"); // TODO(10)
+    it("should match on no patterns, basic sources", async () => {
+      mock({
+        src: {
+          "index.js": "module.exports = 'foo';"
+        }
+      });
+
+      expect(await compare({})).to.eql([
+        "src/index.js"
+      ]);
+    });
+
+    it("should handle broad exclude and include re-adding in", async () => {
+      mock({
+        src: {
+          "index.js": "module.exports = 'index';",
+          "bar.js": "module.exports = 'bar';",
+          "baz.js": "module.exports = 'baz';",
+          stuff: {
+            "what.css": "what",
+            "what.svg": "what"
+          }
+        }
+      });
+
+      expect(await compare({
+        pkgExclude: [
+          "**/b*.js",
+          "**/*.svg"
+        ],
+        pkgInclude: [
+          "src/bar.js"
+        ]
+      })).to.eql([
+        "src/bar.js",
+        "src/index.js",
+        "src/stuff/what.css"
+      ]);
+    });
+
+    it("doesn't removes appropriate serverless.EXT config file", async () => {
+      mock({
+        "serverless.js": "",
+        "serverless.yml": "",
+        src: {
+          "index.js": "module.exports = 'index';"
+        }
+      });
+
+      expect(await compare({})).to.eql([
+        "serverless.js",
+        "src/index.js"
+      ]);
+    });
+
+    it("should handle only node_modules"); // TODO(10)
+    it("should handle sources and node_modules"); // TODO(10)
+  });
 });

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -156,7 +156,58 @@ describe("util/bundle", () => {
       });
     });
 
-    it("should handle missing package.json in collapsed packages"); // TODO
+    it("should handle missing package.json in collapsed packages", async () => {
+      /* eslint-disable camelcase */
+      mock({
+        node_modules: {
+          smooshed: {
+            "package.json": JSON.stringify({ version: "1.0.0" })
+          }
+        }
+      });
+      /* eslint-enable camelcase */
+
+      const files = [
+        "src/server/index.js",
+        "src/server/dates.js",
+        "node_modules/lodash/index.js",
+        "node_modules/lodash/package.json",
+        "node_modules/smooshed/index.js",
+        "node_modules/smooshed/also-no-duplicate.js",
+        "node_modules/smooshed/package.json",
+        "../node_modules/smooshed/index.js",
+        "../node_modules/smooshed/no-duplicate.js",
+        "../node_modules/smooshed/package.json",
+        "../../node_modules/smooshed/index.js",
+        "../../node_modules/smooshed/package.json"
+      ];
+
+      const cwd = path.resolve("level1/level2");
+
+      expect(await findCollapsed({ files, cwd })).to.eql({
+        srcs: {},
+        pkgs: {
+          "node_modules/smooshed": {
+            numTotalFiles: 6,
+            numUniquePaths: 2,
+            packages: [
+              {
+                path: "node_modules/smooshed/package.json",
+                version: null
+              },
+              {
+                path: "../node_modules/smooshed/package.json",
+                version: null
+              },
+              {
+                path: "../../node_modules/smooshed/package.json",
+                version: "1.0.0"
+              }
+            ]
+          }
+        }
+      });
+    });
 
     it("should find collapsed sources", async () => {
       const files = [

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -6,6 +6,7 @@
  */
 
 const path = require("path");
+const { normalize } = path;
 const mock = require("mock-fs");
 
 const Jetpack = require("../../..");
@@ -198,7 +199,7 @@ describe("util/bundle", () => {
       expect(await findCollapsed({ files, cwd })).to.eql({
         srcs: {},
         pkgs: {
-          "@scope/dupsy": {
+          [normalize("@scope/dupsy")]: {
             numTotalFiles: 6,
             numUniquePaths: 2,
             packages: [
@@ -253,7 +254,7 @@ describe("util/bundle", () => {
 
       expect(await findCollapsed({ files })).to.eql({
         srcs: {
-          "src/server": {
+          [normalize("src/server")]: {
             numTotalFiles: 2,
             numUniquePaths: 1
           }

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -120,8 +120,10 @@ describe("util/bundle", () => {
         "node_modules/lodash/index.js",
         "node_modules/lodash/package.json",
         "node_modules/smooshed/index.js",
+        "node_modules/smooshed/also-no-duplicate.js",
         "node_modules/smooshed/package.json",
         "../node_modules/smooshed/index.js",
+        "../node_modules/smooshed/no-duplicate.js",
         "../node_modules/smooshed/package.json",
         "../../node_modules/smooshed/index.js",
         "../../node_modules/smooshed/package.json"
@@ -155,7 +157,30 @@ describe("util/bundle", () => {
     });
 
     it("should handle missing package.json in collapsed packages"); // TODO
-    it("should find collapsed sources"); // TODO
+
+    it("should find collapsed sources", async () => {
+      const files = [
+        "src/server/index.js",
+        "src/server/dates.js",
+        "src/server/no-duplicate.js",
+        "../../wut/../src/server/index.js",
+        "../../wut/../src/server/also-no-dups.js",
+        "node_modules/lodash/index.js",
+        "node_modules/lodash/package.json",
+        "../node_modules/up-a-level/index.js",
+        "../node_modules/up-a-level/package.json"
+      ];
+
+      expect(await findCollapsed({ files })).to.eql({
+        srcs: {
+          "src/server": {
+            numTotalFiles: 2,
+            numUniquePaths: 1
+          }
+        },
+        pkgs: {}
+      });
+    });
   });
 
   describe("#resolveFilePathsFromPatterns", () => {

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -134,7 +134,7 @@ describe("util/bundle", () => {
       expect(await findCollapsed({ files, cwd })).to.eql({
         srcs: {},
         pkgs: {
-          "smooshed": {
+          smooshed: {
             numTotalFiles: 6,
             numUniquePaths: 2,
             packages: [
@@ -160,6 +160,11 @@ describe("util/bundle", () => {
       /* eslint-disable camelcase */
       mock({
         node_modules: {
+          "@scope": {
+            dupsy: {
+              "package.json": JSON.stringify({ version: "1.0.0" })
+            }
+          },
           smooshed: {
             "package.json": JSON.stringify({ version: "1.0.0" })
           }
@@ -179,7 +184,13 @@ describe("util/bundle", () => {
         "../node_modules/smooshed/no-duplicate.js",
         "../node_modules/smooshed/package.json",
         "../../node_modules/smooshed/index.js",
-        "../../node_modules/smooshed/package.json"
+        "../../node_modules/smooshed/package.json",
+        "node_modules/@scope/dupsy/index.js",
+        "node_modules/@scope/dupsy/package.json",
+        "../node_modules/@scope/dupsy/index.js",
+        "../node_modules/@scope/dupsy/package.json",
+        "../mid/../../node_modules/@scope/dupsy/index.js",
+        "../mid/../../node_modules/@scope/dupsy/package.json"
       ];
 
       const cwd = path.resolve("level1/level2");
@@ -187,7 +198,25 @@ describe("util/bundle", () => {
       expect(await findCollapsed({ files, cwd })).to.eql({
         srcs: {},
         pkgs: {
-          "smooshed": {
+          "@scope/dupsy": {
+            numTotalFiles: 6,
+            numUniquePaths: 2,
+            packages: [
+              {
+                path: "node_modules/@scope/dupsy",
+                version: null
+              },
+              {
+                path: "../node_modules/@scope/dupsy",
+                version: null
+              },
+              {
+                path: "../mid/../../node_modules/@scope/dupsy",
+                version: "1.0.0"
+              }
+            ]
+          },
+          smooshed: {
             numTotalFiles: 6,
             numUniquePaths: 2,
             packages: [

--- a/test/spec/util/bundle.spec.js
+++ b/test/spec/util/bundle.spec.js
@@ -134,20 +134,20 @@ describe("util/bundle", () => {
       expect(await findCollapsed({ files, cwd })).to.eql({
         srcs: {},
         pkgs: {
-          "node_modules/smooshed": {
+          "smooshed": {
             numTotalFiles: 6,
             numUniquePaths: 2,
             packages: [
               {
-                path: "node_modules/smooshed/package.json",
+                path: "node_modules/smooshed",
                 version: "3.0.0"
               },
               {
-                path: "../node_modules/smooshed/package.json",
+                path: "../node_modules/smooshed",
                 version: "2.0.0"
               },
               {
-                path: "../../node_modules/smooshed/package.json",
+                path: "../../node_modules/smooshed",
                 version: "1.0.0"
               }
             ]
@@ -187,20 +187,20 @@ describe("util/bundle", () => {
       expect(await findCollapsed({ files, cwd })).to.eql({
         srcs: {},
         pkgs: {
-          "node_modules/smooshed": {
+          "smooshed": {
             numTotalFiles: 6,
             numUniquePaths: 2,
             packages: [
               {
-                path: "node_modules/smooshed/package.json",
+                path: "node_modules/smooshed",
                 version: null
               },
               {
-                path: "../node_modules/smooshed/package.json",
+                path: "../node_modules/smooshed",
                 version: null
               },
               {
-                path: "../../node_modules/smooshed/package.json",
+                path: "../../node_modules/smooshed",
                 version: "1.0.0"
               }
             ]

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -228,8 +228,14 @@ const summarizeCollapsed = ({ map, cwd, isPackages = false }) => {
         if (isPackages) {
           const pkgJsonPaths = filesMap[path.join(group, "package.json")];
           base.packages = await Promise.all(pkgJsonPaths.map(async (pkgJsonPath) => {
-            const pkgString = await readFile(path.resolve(cwd, pkgJsonPath));
-            const { version } = JSON.parse(pkgString);
+            const version = await readFile(path.resolve(cwd, pkgJsonPath))
+              .then((pkgString) => JSON.parse(pkgString).version)
+              .catch((err) => {
+                // Shouldn't really happen, but allow missing package.json from disk.
+                if (err.code === "ENOENT") { return null; }
+                throw err;
+              });
+
             return {
               path: pkgJsonPath,
               version

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -466,8 +466,6 @@ const globAndZip = async ({
   // https://github.com/FormidableLabs/serverless-jetpack/issues/109
   const collapsed = await findCollapsed({ files: included, cwd });
 
-  // TODO(collapsed): Consider option to throw exception here?
-
   // Create package zip.
   await bundle.createZip({
     files: included,

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -226,7 +226,7 @@ const summarizeCollapsed = ({ map, cwd, isPackages = false }) => {
       .map(async ([group, filesMap]) => {
         const base = {};
         if (isPackages) {
-          const pkgJsonPaths = filesMap[path.join("node_modules", group, "package.json")];
+          const pkgJsonPaths = filesMap[path.join("node_modules", group, "package.json")] || [];
           base.packages = await Promise.all(pkgJsonPaths.map(async (pkgJsonPath) => {
             const version = await readFile(path.resolve(cwd, pkgJsonPath))
               .then((pkgString) => JSON.parse(pkgString).version)

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -195,10 +195,10 @@ const collapsedPath = (filePath) => {
   if (parts[0] === "node_modules") {
     if (parts.length >= PKG_SCOPED_PARTS && parts[1][0] === "@") {
       // Scoped.
-      pkg = parts.slice(0, PKG_SCOPED_PARTS).join(path.sep);
+      pkg = parts.slice(1, PKG_SCOPED_PARTS).join(path.sep);
     } else if (parts.length >= PKG_NORMAL_PARTS && parts[1][0] !== "@") {
       // Unscoped.
-      pkg = parts.slice(0, PKG_NORMAL_PARTS).join(path.sep);
+      pkg = parts[1];
     }
   }
 
@@ -226,7 +226,7 @@ const summarizeCollapsed = ({ map, cwd, isPackages = false }) => {
       .map(async ([group, filesMap]) => {
         const base = {};
         if (isPackages) {
-          const pkgJsonPaths = filesMap[path.join(group, "package.json")];
+          const pkgJsonPaths = filesMap[path.join("node_modules", group, "package.json")];
           base.packages = await Promise.all(pkgJsonPaths.map(async (pkgJsonPath) => {
             const version = await readFile(path.resolve(cwd, pkgJsonPath))
               .then((pkgString) => JSON.parse(pkgString).version)
@@ -237,7 +237,7 @@ const summarizeCollapsed = ({ map, cwd, isPackages = false }) => {
               });
 
             return {
-              path: pkgJsonPath,
+              path: path.dirname(pkgJsonPath),
               version
             };
           }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,6 +1121,13 @@ caw@^2.0.1:
     tunnel-agent "^0.6.0"
     url-to-options "^1.0.1"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"


### PR DESCRIPTION
For #109 (completes most tasks).

## Work

- [x] Detect and issue warnings for collapsed files in package.
- [x] Add `jetpack.collapsed.bail` option to kill serverless on detected conflicts.

## Future work

- [ ] Ticket / consider `jetpack.collapsed.resolutions` or something to resolve conflicts to a single directory. Probably just for `node_modules` things.

/cc @pdeona @mscottx88 @tptee 