### PR TITLE
Feature: Report on trace mode dynamic import "misses".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: Add log warnings and `--report` information for missed dynamic imports in tracing mode.
+* Bug: Fix `--report` on collapsed sources and dependencies.
+
 ## 0.10.2
 
 * Feature: Detect and issue warnings for collapsed files in package. Add `jetpack.collapsed.bail` option to kill serverless on detected conflicts.

--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ functions:
 * **Layers are not traced**: Because Layers don't have a distinct entry point, they will not be traced. Instead Jetpack does normal pattern-based production dependency inference.
 
 * **Static analysis only**: Tracing will only detect files included via `require("A_STRING")`, `require.resolve("A_STRING")`, `import "A_STRING"`, and `import NAME from "A_STRING"`. It will not work with dynamic `import()`s or `require`s that dynamically inject a variable etc. like `require(myVariable)`.
+    * **Note**: Jetpack will log warnings for files found that have imports that tracing missed. See `WARNING` log output for the list of files. You can then run a full report (e.g., `serverless jetpack package --report`) for a full list of each missed import with file path, source code, and line + column numbers provided for your review. You should take this output that then manually inspect the files in question to see if you need to include additional hidden dependencies via `package.include` (straight inclusion) or `jetpack.trace.include` (inclusion that traces dependencies).
 
 ### Tracing Results
 

--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ class Jetpack {
     if (!srcsLen && !pkgsLen) { return; }
 
     if (srcsLen) {
-      const srcsReport = this._collapsedReport(collapsed.srcs);
+      const srcsReport = this._collapsedReport(collapsed.srcs).join("\n");
 
       this._logWarning(
         `Found ${srcsLen} collapsed source files in ${bundleName}! `
@@ -432,7 +432,7 @@ class Jetpack {
     }
 
     if (pkgsLen) {
-      const pkgReport = this._collapsedReport(collapsed.pkgs);
+      const pkgReport = this._collapsedReport(collapsed.pkgs).join("\n");
 
       this._logWarning(
         `Found ${pkgsLen} collapsed dependencies in ${bundleName}! `

--- a/index.js
+++ b/index.js
@@ -376,6 +376,16 @@ class Jetpack {
     };
   }
 
+  _traceMissesReport(misses) {
+    return Object.entries(misses)
+      .map(([depPath, missList]) =>
+        missList.map(({ src, loc: { start: { line, column } } }) =>
+          `- ${depPath} [${line}:${column}]: ${src}`
+        )
+      )
+      .reduce((arr, missList) => arr.concat(missList), []);
+  }
+
   _collapsedReport(summary) {
     const pkgsReport = (packages) => packages ? `: [${
       Object.values(packages).map((obj) => `${obj.path}@${obj.version}`).join(", ")
@@ -384,8 +394,22 @@ class Jetpack {
     return Object.entries(summary)
       .map(([group, { packages, numUniquePaths, numTotalFiles }]) =>
         `- ${group} (${numUniquePaths} unique, ${numTotalFiles} total)${pkgsReport(packages)}`
-      )
-      .join("\n");
+      );
+  }
+
+  // Handle tracing misses
+  _handleTraceMisses({ misses, bundleName }) {
+    const files = Object.keys(misses);
+    if (files.length) {
+      this._logWarning(
+        `Found ${files.length} source files with tracing misses in ${bundleName}! `
+        + "Please review report (`serverless jetpack package --report`) for details."
+      );
+      this._log(
+        `${bundleName} source files with tracing misses: ${JSON.stringify(files)}`,
+        { color: "gray" }
+      );
+    }
   }
 
   // Handle collapsed duplicates.
@@ -429,6 +453,7 @@ class Jetpack {
 
   _report({ results }) {
     const INDENT = 6;
+    const JOIN_STR = `${"\n"}${" ".repeat(INDENT)}`;
     /* eslint-disable max-len*/
     const bundles = results
       .map(({ bundlePath, roots, patterns, files, trace, collapsed }) => `
@@ -436,14 +461,14 @@ class Jetpack {
 
       - Path: ${bundlePath}
       - Roots: ${roots ? "" : "(None)"}
-      ${(roots || []).map((p) => `    - '${p}'`).join("\n      ")}
+      ${(roots || []).map((p) => `    - '${p}'`).join(JOIN_STR)}
 
       ### Trace: Configuration
 
       # Ignores (\`${trace.ignores.length}\`):
-      ${trace.ignores.map((p) => `- '${p}'`).join("\n      ")}
+      ${trace.ignores.map((p) => `- '${p}'`).join(JOIN_STR)}
       # Allowed Missing (\`${Object.keys(trace.allowMissing).length}\`):
-      ${Object.keys(trace.allowMissing).map((k) => `- '${k}': ${JSON.stringify(trace.allowMissing[k])}`).join("\n      ")}
+      ${Object.keys(trace.allowMissing).map((k) => `- '${k}': ${JSON.stringify(trace.allowMissing[k])}`).join(JOIN_STR)}
 
       ### Patterns: Include
 
@@ -451,37 +476,41 @@ class Jetpack {
       # Automatically added
       - '**'
       # Jetpack (\`${patterns.preInclude.length}\`): \`custom.jetpack.preInclude\` + \`function.{NAME}.jetpack.preInclude\`
-      ${patterns.preInclude.map((p) => `- '${p}'`).join("\n      ")}
+      ${patterns.preInclude.map((p) => `- '${p}'`).join(JOIN_STR)}
       # Jetpack (\`${patterns.depInclude.length}\`): dependency filtering mode additions
-      ${patterns.depInclude.map((p) => `- '${p}'`).join("\n      ")}
+      ${patterns.depInclude.map((p) => `- '${p}'`).join(JOIN_STR)}
       # Jetpack (\`${patterns.traceInclude.length}\`): trace mode additions
-      ${patterns.traceInclude.map((p) => `- '${p}'`).join("\n      ")}
+      ${patterns.traceInclude.map((p) => `- '${p}'`).join(JOIN_STR)}
       # Serverless (\`${patterns.include.length}\`): \`package.include\` + \`function.{NAME}.package.include\` + internal extras
-      ${patterns.include.map((p) => `- '${p}'`).join("\n      ")}
+      ${patterns.include.map((p) => `- '${p}'`).join(JOIN_STR)}
       \`\`\`
 
       ### Patterns: Exclude
 
       \`\`\`yml
       # Serverless (\`${patterns.exclude.length}\`): \`package.exclude\` + \`function.{NAME}.exclude\` + internal extras
-      ${patterns.exclude.map((p) => `- '${p}'`).join("\n      ")}
+      ${patterns.exclude.map((p) => `- '${p}'`).join(JOIN_STR)}
       \`\`\`
 
       ### Files (\`${files.included.length}\`): Included
 
-      ${files.included.sort().map((p) => `- ${p}`).join("\n      ")}
+      ${files.included.sort().map((p) => `- ${p}`).join(JOIN_STR)}
 
       ### Files (\`${files.excluded.length}\`): Excluded
 
-      ${files.excluded.sort().map((p) => `- ${p}`).join("\n      ")}
+      ${files.excluded.sort().map((p) => `- ${p}`).join(JOIN_STR)}
+
+      ### Trace Misses (\`${Object.keys(trace.misses).length}\` files)
+
+      ${this._traceMissesReport(trace.misses).join(JOIN_STR)}
 
       ### Collapsed (\`${Object.keys(collapsed.srcs).length}\`): Sources
 
-      ${this._collapsedReport(collapsed.srcs)}
+      ${this._collapsedReport(collapsed.srcs).join(JOIN_STR)}
 
       ### Collapsed (\`${Object.keys(collapsed.pkgs).length}\`): Dependencies
 
-      ${this._collapsedReport(collapsed.pkgs)}
+      ${this._collapsedReport(collapsed.pkgs).join(JOIN_STR)}
       `)
       .join("\n");
     /* eslint-enable max-len*/
@@ -616,7 +645,10 @@ class Jetpack {
     const results = await this.globAndZip({
       bundleName, functionObject, traceInclude, traceParams, worker, report
     });
-    const { buildTime, collapsed } = results;
+    const { buildTime, collapsed, trace } = results;
+    if (mode === "trace") {
+      this._handleTraceMisses({ misses: trace.misses, bundleName });
+    }
 
     const { bail } = this._extraOptions({ functionObject }).collapsed;
     this._handleCollapsed({ collapsed, bundleName, bail });
@@ -629,6 +661,7 @@ class Jetpack {
     return { packageType: "function", ...results };
   }
 
+  // eslint-disable-next-line max-statements
   async packageService({ functionObjects, worker, report }) {
     const { service } = this.serverless;
     const serviceName = service.service;
@@ -646,7 +679,10 @@ class Jetpack {
     const results = await this.globAndZip({
       bundleName, traceInclude, traceParams, worker, report
     });
-    const { buildTime, collapsed } = results;
+    const { buildTime, collapsed, trace } = results;
+    if (mode === "trace") {
+      this._handleTraceMisses({ misses: trace.misses, bundleName });
+    }
 
     const { bail } = this._serviceOptions.collapsed;
     this._handleCollapsed({ collapsed, bundleName, bail });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "make-dir": "^3.0.2",
     "nanomatch": "^1.2.13",
     "p-limit": "^2.3.0",
-    "trace-deps": "FormidableLabs/trace-deps#feature/dynamic-imports"
+    "trace-deps": "^0.3.0"
   },
   "devDependencies": {
     "adm-zip": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "make-dir": "^3.0.2",
     "nanomatch": "^1.2.13",
     "p-limit": "^2.3.0",
-    "trace-deps": "^0.2.4"
+    "trace-deps": "FormidableLabs/trace-deps#feature/dynamic-imports"
   },
   "devDependencies": {
     "adm-zip": "^0.4.14",

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -670,7 +670,7 @@ describe("index", () => {
   });
 
   describe("collapsed zip", () => {
-    it.only("warns on collapsed files", async () => {
+    it("warns on collapsed files", async () => {
       // Don't actually read disk and bundle.
       sandbox.stub(Jetpack.prototype, "globAndZip").returns(Promise.resolve({
         buildTime: 0,

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -474,7 +474,10 @@ describe("index", () => {
         // Don't actually read disk and bundle.
         sandbox.stub(Jetpack.prototype, "globAndZip").returns(Promise.resolve({
           buildTime: 0,
-          collapsed: { srcs: {}, pkgs: {} }
+          collapsed: { srcs: {}, pkgs: {} },
+          trace: {
+            misses: {}
+          }
         }));
       });
 
@@ -667,11 +670,14 @@ describe("index", () => {
   });
 
   describe("collapsed zip", () => {
-    it("warns on collapsed files", async () => {
+    it.only("warns on collapsed files", async () => {
       // Don't actually read disk and bundle.
       sandbox.stub(Jetpack.prototype, "globAndZip").returns(Promise.resolve({
         buildTime: 0,
-        collapsed: { srcs: {}, pkgs: {} }
+        collapsed: { srcs: {}, pkgs: {} },
+        trace: {
+          misses: {}
+        }
       }));
 
       mock({
@@ -765,6 +771,9 @@ describe("index", () => {
                 numTotalFiles: 216
               }
             }
+          },
+          trace: {
+            misses: {}
           }
         }));
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5463,10 +5463,17 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1:
+resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.15.1:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.0.tgz#063dc704fa3413e13ac1d0d1756a7cbfe95dd1a7"
+  integrity sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==
   dependencies:
     path-parse "^1.0.6"
 
@@ -6365,7 +6372,7 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
 
 trace-deps@FormidableLabs/trace-deps#feature/dynamic-imports:
   version "0.2.4"
-  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/c3cb2f00c87d3816b7b29bf2239b569e7dc8a238"
+  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/e56d029cfddb53c128ae8eb6da055b4a18c55613"
   dependencies:
     acorn-node "^2.0.0"
     resolve "^1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6363,10 +6363,9 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-trace-deps@^0.2.4:
+trace-deps@FormidableLabs/trace-deps#feature/dynamic-imports:
   version "0.2.4"
-  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.2.4.tgz#03f6bfef2cae85add3be35747f8986ac2fa71594"
-  integrity sha512-Ji8nWNQsN62EUDzN2zTKQMRGp1cOay6WNZi+3//k8Sl3QjbSPK0DC/7u7+o8IfJ2LuKKEIk2HX7M51MgqSXLmQ==
+  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/c3cb2f00c87d3816b7b29bf2239b569e7dc8a238"
   dependencies:
     acorn-node "^2.0.0"
     resolve "^1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6370,9 +6370,10 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-trace-deps@FormidableLabs/trace-deps#feature/dynamic-imports:
-  version "0.2.4"
-  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/e56d029cfddb53c128ae8eb6da055b4a18c55613"
+trace-deps@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.3.0.tgz#ac53b04d4c89c80b7ae4057de14d509b53657523"
+  integrity sha512-XZuFVyiBTynufC5TRfD5JBDJR4r3fwekMyJtoCT/xG/uwkhoQ6S2cG1ZDxfsyjjy96gc5F1p+8QFb0SvDW/fwg==
   dependencies:
     acorn-node "^2.0.0"
     resolve "^1.15.1"


### PR DESCRIPTION
## Work

* Feature: Add log warnings and `--report` information for missed dynamic imports in tracing mode.
* Bug: Fix `--report` on collapsed sources and dependencies.

## Tasks
- [x] Switch to published version once https://github.com/FormidableLabs/trace-deps/pull/27 is merged

## Sample output

Logs:

```
Serverless: [serverless-jetpack] WARNING: Found 1 source files with tracing misses in .serverless/serverless-jetpack-huge-prod.zip! Please review report (`serverless jetpack package --report`) for details.
Serverless: [serverless-jetpack] .serverless/serverless-jetpack-huge-prod.zip source files with tracing misses: ["node_modules/express/lib/view.js"]
```

Report:

```
### Trace Misses (`1` files)

- node_modules/express/lib/view.js [81:13]: require(mod)
```

/cc @pdeona @mscottx88 @tptee @aisapatino 