### PR TITLE
Feature: Add `jetpack.trace.dynamic.*` options.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,8 @@ workflows:
           name: build-linux-node-12
           executor_tag: '12'
       - build_and_test:
-          name: build-linux-node-13
-          executor_tag: '13'
+          name: build-linux-node-14
+          executor_tag: '14'
       # TODO(83): Out of windows OSS credits
       # See: https://github.com/FormidableLabs/serverless-jetpack/issues/83
       # - build_and_test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes
 ## UNRELEASED
 
 * Feature: Add `jetpack.trace.dynamic.bail` option.
+* Internal: Minor refactor of patterns passed for trace includes to globbing handlers. Also standardize options passed to `globby()` across different functions.
 * TODO(trace-options): `jetpack.trace.dynamic.resolutions`
 
 ## 0.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ Changes
 
 ## UNRELEASED
 
-* Feature: Add `jetpack.trace.misses.bail` option.
-* TODO(trace-options): `jetpack.trace.misses.resolutions`
+* Feature: Add `jetpack.trace.dynamic.bail` option.
+* TODO(trace-options): `jetpack.trace.dynamic.resolutions`
 
 ## 0.10.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes
 ## UNRELEASED
 
 * Feature: Add `jetpack.trace.dynamic.bail` option.
-* TODO(trace-options): `jetpack.trace.dynamic.resolutions`
+* Feature: Add `jetpack.trace.dynamic.resolutions` option.
 * Internal: Minor refactor of patterns passed for trace includes to globbing handlers. Also standardize options passed to `globby()` across different functions.
 * Internal: Enhance and refactor trace miss logging as well as the `--report` format for trace misses to collapse packages.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: Add `jetpack.trace.misses.bail` option.
+* TODO(trace-options): `jetpack.trace.misses.resolutions`
+
 ## 0.10.4
 
 * Misc: Add better collapsed packages log information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Changes
 ## UNRELEASED
 
 * Feature: Add `jetpack.trace.dynamic.bail` option.
-* Internal: Minor refactor of patterns passed for trace includes to globbing handlers. Also standardize options passed to `globby()` across different functions.
 * TODO(trace-options): `jetpack.trace.dynamic.resolutions`
+* Internal: Minor refactor of patterns passed for trace includes to globbing handlers. Also standardize options passed to `globby()` across different functions.
+* Internal: Enhance and refactor trace miss logging as well as the `--report` format for trace misses to collapse packages.
 
 ## 0.10.4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,9 @@ $ SERVERLESS_ACCESS_KEY="<INSERT_HERE>" yarn benchmark:test
 Before you go ahead and submit a PR, make sure that you have done the following:
 
 ```sh
+# Update the documentation TOCs (and commit changes).
+$ yarn run build
+
 # Run lint and unit tests
 $ yarn run check
 

--- a/README.md
+++ b/README.md
@@ -629,12 +629,10 @@ and produces combined `--report` output like:
 ### Tracing Dynamic Misses (`6` packages): Dependencies
 
 ...
-- `colors`
-    - ../node_modules/aws-xray-sdk-core/node_modules/colors/lib/colors.js [127:29]: require(theme)
-- `bunyan`
-    - ../node_modules/bunyan/lib/bunyan.js [79:17]: require('dtrace-provider' + '')
-    - ../node_modules/bunyan/lib/bunyan.js [100:13]: require('mv' + '')
-    - ../node_modules/bunyan/lib/bunyan.js [106:27]: require('source-map-support' + '')
+- ../node_modules/aws-xray-sdk-core/node_modules/colors/lib/colors.js [127:29]: require(theme)
+- ../node_modules/bunyan/lib/bunyan.js [79:17]: require('dtrace-provider' + '')
+- ../node_modules/bunyan/lib/bunyan.js [100:13]: require('mv' + '')
+- ../node_modules/bunyan/lib/bunyan.js [106:27]: require('source-map-support' + '')
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -477,7 +477,8 @@ The basic `trace` Boolean field should hopefully work for most cases. Jetpack pr
     * **Note**: These patterns are in _addition_ to the handler inferred file path. If you want to exclude the handler path you could technically do a `!file/path.js` exclusion, but that would be a strange case in that your handler files would no longer be present.
 * `trace.dynamic.bail` (`Boolean`): Terminate `serverless` program with an error if dynamic import misses are detected. See [discussion below](#handling-dynamic-import-misses) regarding handling.
 * `trace.dynamic.resolutions` (`Object.<string, Array<string>>`): Handle dynamic import misses by providing a key to match misses on and an array of additional glob patterns to trace and include in the application bundle.
-    * _Application source files_: If a miss is an application source file (e.g., not within `node_modules`), specify the **relative path** to it like `"src/server/router.js": [/* array of patterns */]`.
+    * _Application source files_: If a miss is an application source file (e.g., not within `node_modules`), specify the **relative path** (from `servicePath` / CWD) to it like `"./src/server/router.js": [/* array of patterns */]`.
+        * **Note**: To be an application source path, it **must** be prefixed with a dot (e.g., `./src/server.js`, `../lower/src/server.js`). Basically, like the Node.js `require()` rules go for a local path file vs. a package dependency.
     * _Dependency packages_: If a miss is part of a dependency (e.g., an `npm` package placed within `node_modules`), specify the **package name** path like `"bunyan": [/* array of patterns */]`.
     * _Ignoring dynamic import misses_: If you just want to ignore the missed dynamic imports for a given application source file or package, just specify and empty array `[]` or falsey value.
 

--- a/README.md
+++ b/README.md
@@ -476,7 +476,12 @@ The basic `trace` Boolean field should hopefully work for most cases. Jetpack pr
 * `trace.include` (`Array<string>`): Additional file path globbing patterns (relative to `servicePath`) to be included in the package and be further traced for dependencies to include. Applies to functions that are part of a service or function (`individually`) packaging.
     * **Note**: These patterns are in _addition_ to the handler inferred file path. If you want to exclude the handler path you could technically do a `!file/path.js` exclusion, but that would be a strange case in that your handler files would no longer be present.
 * `trace.dynamic.bail` (`Boolean`): Terminate `serverless` program with an error if dynamic import misses are detected. See [discussion below](#handling-dynamic-import-misses) regarding handling.
-* TODO(tracing-options) `trace.dynamic.resolutions`
+* `trace.dynamic.resolutions` (`Object.<string, Array<string>>`): Handle dynamic import misses by providing a key to match misses on and an array of additional glob patterns to trace and include in the application bundle.
+    * _Application source files_: If a miss is an application source file (e.g., not within `node_modules`), specify the **relative path** to it like `"src/server/router.js": [/* array of patterns */]`.
+    * _Dependency packages_: If a miss is part of a dependency (e.g., an `npm` package placed within `node_modules`), specify the **package name** path like `"bunyan": [/* array of patterns */]`.
+    * _Ignoring dynamic import misses_: If you just want to ignore the missed dynamic imports for a given application source file or package, just specify and empty array `[]` or falsey value.
+
+ A way to allow certain packages to have potentially failing dependencies. Specify each object key as a package name and value as an array of dependencies that _might_ be missing on disk. If the sub-dependency is found, then it is included in the bundle (this part distinguishes this option from `ignores`). If not, it is skipped without error.
 
 The following **function**-level configurations available via `functions.{FN_NAME}.jetpack.trace` and  `layers.{LAYER_NAME}.jetpack.trace`:
 
@@ -485,7 +490,7 @@ The following **function**-level configurations available via `functions.{FN_NAM
 * `trace.allowMissing` (`Object.<string, Array<string>>`): An object of package path prefixes mapping to lists of packages that are allowed to be missing **if** the function is being packaged `individually`. If there is a service-level `trace.allowMissing` object then the function-level ones will be smart **merged** into the list.
 * `trace.include` (`Array<string>`): Additional file path globbing patterns (relative to `servicePath`) to be included in the package and be further traced for dependencies to include. Applies to functions that are part of a service or function (`individually`) packaging. If there are service-level `trace.include`s then the function-level ones will be **added** to the list.
 * `trace.dynamic.bail` (`Boolean`): Terminate `serverless` program with an error if dynamic import misses are detected **if** the function is being packaged `individually`.
-* TODO(tracing-options) `trace.dynamic.resolutions`
+* `trace.dynamic.resolutions` (`Object.<string, Array<string>>`): An object of application source file or package name keys mapping to lists of pattern globs that are traced and included in the application bundle **if** the function is being packaged `individually`. If there is a service-level `trace.dynamic.resolutions` object then the function-level ones will be smart **merged** into the list.
 
 Let's see the advanced options in action:
 

--- a/README.md
+++ b/README.md
@@ -588,21 +588,22 @@ Dynamic imports that use variables or runtime execution like `require(A_VARIABLE
 The first step is to be aware and watch for dynamic import misses. Conveniently, Jetpack logs warnings like the following:
 
 ```
-Serverless: [serverless-jetpack] WARNING: Found 10 source files with tracing dynamic import misses in .serverless/FN_NAME.zip! Please see logs and read: https://npm.im/serverless-jetpack#handling-dynamic-import-misses
-Serverless: [serverless-jetpack] .serverless/FN_NAME.zip source files with tracing dynamic import misses: [/* ... */,"../node_modules/bindings/bindings.js","../node_modules/bunyan/lib/bunyan.js",/* ... */]
+Serverless: [serverless-jetpack] WARNING: Found 6 dependency packages with tracing misses in .serverless/FN_NAME.zip! Please see logs and read: https://npm.im/serverless-jetpack#handling-dynamic-import-misses
+Serverless: [serverless-jetpack] .serverless/FN_NAME.zip dependency package tracing misses: [* ... */,"colors","bunyan",/* ... */]
 ```
 
 and produces combined `--report` output like:
 
 ```md
-### Trace Dynamic Misses (`10` files)
+### Tracing Dynamic Misses (`6` packages): Dependencies
 
 ...
-- ../node_modules/bindings/bindings.js [76:22]: require.resolve(n)
-- ../node_modules/bindings/bindings.js [76:43]: require(n)
-- ../node_modules/bunyan/lib/bunyan.js [79:17]: require('dtrace-provider' + '')
-- ../node_modules/bunyan/lib/bunyan.js [100:13]: require('mv' + '')
-- ../node_modules/bunyan/lib/bunyan.js [106:27]: require('source-map-support' + '')
+- `colors`
+    - ../node_modules/aws-xray-sdk-core/node_modules/colors/lib/colors.js [127:29]: require(theme)
+- `bunyan`
+    - ../node_modules/bunyan/lib/bunyan.js [79:17]: require('dtrace-provider' + '')
+    - ../node_modules/bunyan/lib/bunyan.js [100:13]: require('mv' + '')
+    - ../node_modules/bunyan/lib/bunyan.js [106:27]: require('source-map-support' + '')
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,34 @@ The Serverless framework is a **fantastic** one-stop-shop for taking your code a
 
 With the `serverless-jetpack` plugin, many common, slow Serverless packaging scenarios can be dramatically sped up. All with a very easy, seamless integration into your existing Serverless projects.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Usage](#usage)
+  - [The short, short version](#the-short-short-version)
+  - [A little more detail...](#a-little-more-detail)
+  - [Configuration](#configuration)
+- [How Jetpack's faster dependency filtering works](#how-jetpacks-faster-dependency-filtering-works)
+  - [The nitty gritty of why it's faster](#the-nitty-gritty-of-why-its-faster)
+  - [Complexities](#complexities)
+    - [Other Serverless plugins that set `package.artifact`](#other-serverless-plugins-that-set-packageartifact)
+    - [Minor differences vs. Serverless globbing](#minor-differences-vs-serverless-globbing)
+    - [Layers](#layers)
+    - [Be careful with `include` configurations and `node_modules`](#be-careful-with-include-configurations-and-node_modules)
+    - [Packaging Files Outside CWD](#packaging-files-outside-cwd)
+- [Tracing Mode](#tracing-mode)
+  - [Tracing Configuration](#tracing-configuration)
+    - [Tracing Options](#tracing-options)
+  - [Tracing Caveats](#tracing-caveats)
+  - [Handling Dynamic Import Misses](#handling-dynamic-import-misses)
+  - [Tracing Results](#tracing-results)
+- [Command Line Interface](#command-line-interface)
+- [Benchmarks](#benchmarks)
+- [Maintenance Status](#maintenance-status)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Usage
 
 ### The short, short version
@@ -625,7 +653,7 @@ Results:
 
 Jetpack also provides some CLI options.
 
-### `serverless jetpack package`
+**`serverless jetpack package`**
 
 Package a function like `serverless package` does, just with better options.
 

--- a/README.md
+++ b/README.md
@@ -483,14 +483,15 @@ package:
 
 functions:
   # Functions in service package.
-  # - `jetpack.trace` option `ignores` does not apply.
-  # - `jetpack.include` **will** include and trace additional files.
+  # - `jetpack.trace.ignores` does not apply.
+  # - `jetpack.trace.include` **will** include and trace additional files.
   service-packaged-app-1:
     handler: app1.handler
 
   service-packaged-app-2:
     handler: app2.handler
     jetpack:
+      # - `jetpack.trace.allowMissing` additions are merged into service level
       trace:
         # Trace and include: `app2.js` + `extra/**.js` patterns
         include:

--- a/README.md
+++ b/README.md
@@ -508,6 +508,32 @@ custom:
         "ws":
           - "bufferutil"
           - "utf-8-validate"
+      dynamic:
+        # Force errors if have unresolved dynamic imports
+        bail: true
+        # Resolve encountered dynamic import misses, either by tracing
+        # additional files, or ignoring after confirmation of safety.
+        resolutions:
+          # **Application Source**
+          #
+          # Specify relative path to application source files to do resolutions
+          # (either trace more files, or set to falsey value to ignore)
+          "src/server/config.js":
+            # Manually trace all configuration files for bespoke configuration
+            # application code.
+            - "src/config/**/*.js"
+
+          # **Dependencies**
+          #
+          # Resolve the dynamic imports by include additional globs to trace.
+          # In this case, `@heroku/socksv5` is dynamically importing _other_
+          # files from the same library, so just add those and trace any
+          # additional dependencies from them.
+          "@heroku/socksv5":
+            - "node_modules/@heroku/socksv5/lib/**/*.js"
+          # The dynamic import from `colors` was a theme loader, which we aren't
+          # using. Ignore with just an empty value, `false`, `null`, or empty array `[]`.
+          "colors": null
 
 package:
   include:

--- a/README.md
+++ b/README.md
@@ -526,9 +526,9 @@ custom:
           # with a dot.
           "./src/server/config.js":
             # Manually trace all configuration files for bespoke configuration
-            # application code.
-            - "src/config/default.js"
-            - "src/config/production.js"
+            # application code. (Note these are relative to the file key!)
+            - "../../config/default.js"
+            - "../../config/production.js"
 
           # Ignore dynamic import misses with empty array.
           "./src/something-else.js": []

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ functions:
 
 ### Handling Dynamic Import Misses
 
-Dynamic imports that use variables like `require(A_VARIABLE)` or ``import(`template_${VARIABLE}`)`` cannot be used by Jetpack to infer what the underlying dependency files are for inclusion in the bundle. That means some level of developer work to handle.
+Dynamic imports that use variables or runtime execution like `require(A_VARIABLE)` or ``import(`template_${VARIABLE}`)`` cannot be used by Jetpack to infer what the underlying dependency files are for inclusion in the bundle. That means some level of developer work to handle.
 
 **Identify**
 
@@ -604,7 +604,7 @@ and produces combined `--report` output like:
 
 which gives you the line + column number of the dynamic dependency in a given source file and snippet of the code in question.
 
-In addition to just logging this information, you can ensure you have no unaccounted for dynamic import misses by setting `jetpack.trace.misses.bail = true` in your applicable service or function-level configuration.
+In addition to just logging this information, you can ensure you have no unaccounted for dynamic import misses by setting `jetpack.trace.dynamic.bail = true` in your applicable service or function-level configuration.
 
 **Diagnose**
 

--- a/README.md
+++ b/README.md
@@ -543,8 +543,12 @@ functions:
 
 * **Layers are not traced**: Because Layers don't have a distinct entry point, they will not be traced. Instead Jetpack does normal pattern-based production dependency inference.
 
-* **Static analysis only**: Tracing will only detect files included via `require("A_STRING")`, `require.resolve("A_STRING")`, `import "A_STRING"`, and `import NAME from "A_STRING"`. It will not work with dynamic `import()`s or `require`s that dynamically inject a variable etc. like `require(myVariable)`.
-    * **Note**: Jetpack will log warnings for files found that have imports that tracing missed. See `WARNING` log output for the list of files. You can then run a full report (e.g., `serverless jetpack package --report`) for a full list of each missed import with file path, source code, and line + column numbers provided for your review. You should take this output that then manually inspect the files in question to see if you need to include additional hidden dependencies via `package.include` (straight inclusion) or `jetpack.trace.include` (inclusion that traces dependencies).
+* **Static analysis by default**: Out of the box, tracing will only detect files included via `require("A_STRING")`, `require.resolve("A_STRING")`, `import "A_STRING"`, and `import NAME from "A_STRING"`. It will not work with dynamic `import()`s or `require`s that dynamically inject a variable etc. like `require(myVariable)`.
+    * **Note**: Jetpack will log warnings for files found that have dynamic imports that tracing missed. See `WARNING` log output for the list of files. You can then run a full report (e.g., `serverless jetpack package --report`) for a full list of each missed import with file path, source code, and line + column numbers provided for your review.
+
+* **Dynamic imports**: Whenever you encounter log messages / report summaries for dynamic import misses, then you will need to custom configure how to address the situation.
+    * **Normal Includes**: One option is to manually inspect the files in question to see if you need to include additional hidden dependencies via `package.include` (straight inclusion) or `jetpack.trace.include` (inclusion that traces dependencies).
+    * TODO(trace-options): INSERT_TRACE_MISSES_OPTIONS_HERE
 
 ### Tracing Results
 

--- a/index.js
+++ b/index.js
@@ -369,8 +369,10 @@ class Jetpack {
     return {
       traceInclude,
       traceParams: {
+        // These are **only** parameters to `traceFiles()`.
         ignores: traceObj.ignores,
-        allowMissing: traceObj.allowMissing
+        allowMissing: traceObj.allowMissing,
+        extraImports: traceObj.dynamic.resolutions
       },
       dynamic: traceObj.dynamic
     };

--- a/index.js
+++ b/index.js
@@ -309,8 +309,9 @@ class Jetpack {
     ].forEach((res) => Object.entries(res)
       .filter(([key]) => key.startsWith("."))
       .forEach(([key, val]) => {
+        // Replace key and mutate falsey values to an empty array.
         delete res[key];
-        res[path.resolve(cwd, key)] = val;
+        res[path.resolve(cwd, key)] = val || [];
       }));
 
     return {
@@ -466,21 +467,20 @@ class Jetpack {
       });
     });
 
-    // TODO: HERE
-    // // TODO: Unwind misses format back to straight keys and match resolutions
-    // // TODO: May need to normalize resolutions keys
-    // // TODO: Test win32 resolutions paths
-    // console.log("TODO HERE Start Matching Misses + Resolutions", {
-    //   bundleName,
-    //   cwd,
-    //   srcs,
-    //   resSrcs,
-    //   pkgs,
-    //   resPkgs,
-    //   resolutions
-    // });
+    // TODO: Unwind misses format back to straight keys and match resolutions
+    // TODO: May need to normalize resolutions keys
+    // TODO: Test win32 resolutions paths
+    console.log("TODO HERE Start Matching Misses + Resolutions", {
+      bundleName,
+      cwd,
+      srcs,
+      resSrcs,
+      pkgs,
+      resPkgs,
+      resolutions
+    });
 
-    // return;
+    return;
 
 
     const srcsLen = Object.keys(misses.srcs).length;

--- a/index.js
+++ b/index.js
@@ -27,8 +27,16 @@ const dedent = (str, num) => str
 
 const uniq = (val, i, arr) => val !== arr[i - 1];
 
+// Concatenate two arrays and produce sorted, unique values.
+const smartConcat = (arr1 = [], arr2 = []) => []
+  // Aggregate in service-level includes first
+  .concat(arr1, arr2)
+  // Make unique.
+  .sort()
+  .filter(uniq);
+
 // Merge two objects of form `{ key: [] }`.
-const smartMerge = (obj1, obj2) => []
+const smartMerge = (obj1 = {}, obj2 = {}) => []
   // Get all unique missing package keys.
   .concat(
     Object.keys(obj1),
@@ -39,14 +47,7 @@ const smartMerge = (obj1, obj2) => []
   // Smart merge unique missing values
   .reduce((obj, key) => {
     // Aggregate service and function unique missing values.
-    obj[key] = []
-      .concat(
-        obj1[key] || [],
-        obj2[key] || []
-      )
-      .sort()
-      .filter(uniq);
-
+    obj[key] = smartConcat(obj1[key], obj2[key]);
     return obj;
   }, {});
 
@@ -281,6 +282,7 @@ class Jetpack {
       .filter(uniq);
     serviceObj.dynamic = {
       bail: false,
+      resolutions: {},
       ...serviceObj.dynamic
     };
 
@@ -311,7 +313,7 @@ class Jetpack {
       bail: typeof functionObj.dynamic.bail !== "undefined"
         ? functionObj.dynamic.bail
         : serviceObj.dynamic.bail,
-      // TODO(trace-options): Dynamic merge `dynamic.resolutions`
+      resolutions: smartMerge(serviceObj.dynamic.resolutions, functionObj.dynamic.resolutions),
       ...functionObj.dynamic
     };
 

--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ const dedent = (str, num) => str
 const uniq = (val, i, arr) => val !== arr[i - 1];
 
 // Concatenate two arrays and produce sorted, unique values.
-const smartConcat = (arr1 = [], arr2 = []) => []
+const smartConcat = (arr1, arr2) => []
   // Aggregate in service-level includes first
-  .concat(arr1, arr2)
+  .concat(arr1 || [], arr2 || [])
   // Make unique.
   .sort()
   .filter(uniq);
@@ -38,9 +38,9 @@ const smartConcat = (arr1 = [], arr2 = []) => []
 const smartMerge = (obj1 = {}, obj2 = {}) =>
   // Get all unique missing package keys.
   smartConcat(Object.keys(obj1), Object.keys(obj2))
-  // Smart merge unique missing values
+    // Smart merge unique missing values
     .reduce((obj, key) => {
-    // Aggregate service and function unique missing values.
+      // Aggregate service and function unique missing values.
       obj[key] = smartConcat(obj1[key], obj2[key]);
       return obj;
     }, {});
@@ -292,11 +292,11 @@ class Jetpack {
     functionObj.ignores = smartConcat(serviceObj.ignores, functionObj.ignores);
     functionObj.allowMissing = smartMerge(serviceObj.allowMissing, functionObj.allowMissing);
     functionObj.dynamic = {
+      ...functionObj.dynamic,
       bail: typeof functionObj.dynamic.bail !== "undefined"
         ? functionObj.dynamic.bail
         : serviceObj.dynamic.bail,
-      resolutions: smartMerge(serviceObj.dynamic.resolutions, functionObj.dynamic.resolutions),
-      ...functionObj.dynamic
+      resolutions: smartMerge(serviceObj.dynamic.resolutions, functionObj.dynamic.resolutions)
     };
 
     // Convert **relative** paths in resolutions to absolute paths.

--- a/index.js
+++ b/index.js
@@ -568,10 +568,11 @@ class Jetpack {
     const JOIN_STR = `${"\n"}${" ".repeat(INDENT)}`;
     /* eslint-disable max-len*/
     const bundles = results
-      .map(({ bundlePath, roots, patterns, files, trace, collapsed }) => `
+      .map(({ mode, bundlePath, roots, patterns, files, trace, collapsed }) => `
       ## ${path.basename(bundlePath)}
 
       - Path: ${bundlePath}
+      - Mode: ${mode}
       - Roots: ${roots ? "" : "(None)"}
       ${(roots || []).map((p) => `    - '${p}'`).join(JOIN_STR)}
 

--- a/index.js
+++ b/index.js
@@ -478,7 +478,10 @@ class Jetpack {
     const pkgsLen = Object.keys(pkgs).length;
 
     if (srcsLen) {
-      const srcsReport = JSON.stringify(Object.keys(srcs));
+      // Full report if bailing.
+      const srcsReport = bail
+        ? `\n${this._traceMissesReport(srcs)}`
+        : JSON.stringify(Object.keys(srcs));
 
       this._logWarning(
         `Found ${srcsLen} source files with tracing misses in ${bundleName}! `
@@ -488,7 +491,10 @@ class Jetpack {
     }
 
     if (pkgsLen) {
-      const pkgReport = JSON.stringify(Object.keys(pkgs));
+      // Full report if bailing.
+      const pkgReport = bail
+        ? `\n${this._traceMissesPkgsReport(pkgs)}`
+        : JSON.stringify(Object.keys(pkgs));
 
       this._logWarning(
         `Found ${pkgsLen} dependency packages with tracing misses in ${bundleName}! `

--- a/index.js
+++ b/index.js
@@ -370,9 +370,9 @@ class Jetpack {
       traceInclude,
       traceParams: {
         ignores: traceObj.ignores,
-        allowMissing: traceObj.allowMissing,
-        dynamic: traceObj.dynamic
-      }
+        allowMissing: traceObj.allowMissing
+      },
+      dynamic: traceObj.dynamic
     };
   }
 
@@ -677,7 +677,7 @@ class Jetpack {
     const bundleName = path.join(SLS_TMP_DIR, `${functionName}.zip`);
 
     // Get traces.
-    const { traceInclude, traceParams } = await this._traceOptions({ functionObject });
+    const { traceInclude, traceParams, dynamic } = await this._traceOptions({ functionObject });
     const mode = traceInclude ? "trace" : "dependency";
 
     // Package.
@@ -687,7 +687,7 @@ class Jetpack {
     });
     const { buildTime, collapsed, trace } = results;
     if (mode === "trace") {
-      this._handleTraceMisses({ misses: trace.misses, bundleName, bail: traceParams.dynamic.bail });
+      this._handleTraceMisses({ misses: trace.misses, bundleName, bail: dynamic.bail });
     }
 
     this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });
@@ -711,7 +711,7 @@ class Jetpack {
     const bundleName = path.join(SLS_TMP_DIR, `${serviceName}.zip`);
 
     // Get traces.
-    const { traceInclude, traceParams } = await this._traceOptions({ functionObjects });
+    const { traceInclude, traceParams, dynamic } = await this._traceOptions({ functionObjects });
     const mode = traceInclude ? "trace" : "dependency";
 
     // Package.
@@ -721,7 +721,7 @@ class Jetpack {
     });
     const { buildTime, collapsed, trace } = results;
     if (mode === "trace") {
-      this._handleTraceMisses({ misses: trace.misses, bundleName, bail: traceParams.dynamic.bail });
+      this._handleTraceMisses({ misses: trace.misses, bundleName, bail: dynamic.bail });
     }
 
     this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });

--- a/index.js
+++ b/index.js
@@ -404,11 +404,11 @@ class Jetpack {
     const files = Object.keys(misses);
     if (files.length) {
       this._logWarning(
-        `Found ${files.length} source files with tracing misses in ${bundleName}! `
+        `Found ${files.length} source files with tracing dynamic misses in ${bundleName}! `
         + "Please review report (`serverless jetpack package --report`) for details."
       );
       this._log(
-        `${bundleName} source files with tracing misses: ${JSON.stringify(files)}`,
+        `${bundleName} source files with tracing dynamic misses: ${JSON.stringify(files)}`,
         { color: "gray" }
       );
     }
@@ -502,7 +502,7 @@ class Jetpack {
 
       ${files.excluded.sort().map((p) => `- ${p}`).join(JOIN_STR)}
 
-      ### Trace Misses (\`${Object.keys(trace.misses).length}\` files)
+      ### Trace Dynamic Misses (\`${Object.keys(trace.misses).length}\` files)
 
       ${this._traceMissesReport(trace.misses).join(JOIN_STR)}
 

--- a/index.js
+++ b/index.js
@@ -400,16 +400,23 @@ class Jetpack {
   }
 
   // Handle tracing misses
-  _handleTraceMisses({ misses, bundleName }) {
+  _handleTraceMisses({ misses, bundleName, bail }) {
     const files = Object.keys(misses);
     if (files.length) {
       this._logWarning(
-        `Found ${files.length} source files with tracing dynamic misses in ${bundleName}! `
-        + "Please review report (`serverless jetpack package --report`) for details."
+        `Found ${files.length} source files with tracing dynamic import misses in ${bundleName}! `
+        + "Please see logs and read: https://npm.im/serverless-jetpack#handling-dynamic-import-misses"
       );
       this._log(
-        `${bundleName} source files with tracing dynamic misses: ${JSON.stringify(files)}`,
+        `${bundleName} source files with tracing dynamic import misses: ${JSON.stringify(files)}`,
         { color: "gray" }
+      );
+    }
+
+    if (bail) {
+      throw new Error(
+        `Bailing on ${files.length} missed dynamic imports. `
+        + "Please see logs and read: https://npm.im/serverless-jetpack#handling-dynamic-import-misses"
       );
     }
   }

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const smartMerge = (obj1 = {}, obj2 = {}) =>
       return obj;
     }, {});
 
-const resolveToPosix = (cwd, file) => !file ? file : path.resolve(cwd, file.replace(/\\/g, "/"));
+const toPosix = (file) => !file ? file : file.replace(/\\/g, "/");
 
 /**
  * Package Serverless applications manually.
@@ -414,50 +414,50 @@ class Jetpack {
   // 1. Log / error for trace misses.
   // 2. Generate data for resolutions and remaining misses.
   _handleTraceMisses({ bundleName, misses, resolutions, bail }) {
-    // const cwd = this.serverless.config.servicePath || ".";
+    const cwd = this.serverless.config.servicePath || ".";
 
-    // // Full, normalized paths for all resolutions for matching.
-    // const resSrcs = new Set(Object.keys(resolutions)
-    //   .filter((f) => f.startsWith("."))
-    //   .map((f) => resolveToPosix(cwd, f))
-    // );
+    // Full, normalized paths for all resolutions for matching.
+    const resSrcs = new Set(Object.keys(resolutions)
+      .filter((f) => path.isAbsolute(f))
+      .map((f) => toPosix(f))
+    );
 
-    // // Create a copy of misses and then iterate and mutate to remove the
-    // // entries that were resolved.
-    // const { srcs, pkgs } = JSON.parse(JSON.stringify(misses));
-    // Object.keys(srcs).forEach((relPath) => {
-    //   const fullPath = resolveToPosix(cwd, relPath);
-    //   console.log("TODO HERE", { relPath, fullPath });
-    //   if (resSrcs.has(fullPath)) {
-    //     console.log("TODO HERE SRCS REMOVING", fullPath);
-    //     delete srcs[relPath];
-    //   }
-    // });
+    // Create a copy of misses and then iterate and mutate to remove the
+    // entries that were resolved.
+    const { srcs, pkgs } = JSON.parse(JSON.stringify(misses));
+    Object.keys(srcs).forEach((relPath) => {
+      const fullPath = toPosix(path.resolve(cwd, relPath));
+      console.log("TODO HERE SRCS (before)", { relPath, fullPath });
+      if (resSrcs.has(fullPath)) {
+        console.log("TODO HERE SRCS REMOVING", fullPath);
+        delete srcs[relPath];
+      }
+    });
 
-    // // Normalize the misses + resolutions keys to make sure we match appropriately
-    // // const srcs = Object.keys(misses.srcs).map((f) => resolveToPosix(cwd, f));
-    // // const pkgs = Object.entries(misses.pkgs).reduce((memo, [pkg, pkgMisses]) => {
-    // //   memo[pkg] = Object.entries(pkgMisses).reduce((pkgMemo, [pkgPath, pkgPathMisses]) => {
-    // //     pkgMemo[resolveToPosix(cwd, pkgPath)] = pkgPathMisses;
-    // //     return pkgMemo;
-    // //   }, {});
-    // //   return memo;
-    // // }, {});
+    // Normalize the misses + resolutions keys to make sure we match appropriately
+    // const srcs = Object.keys(misses.srcs).map((f) => resolveToPosix(cwd, f));
+    // const pkgs = Object.entries(misses.pkgs).reduce((memo, [pkg, pkgMisses]) => {
+    //   memo[pkg] = Object.entries(pkgMisses).reduce((pkgMemo, [pkgPath, pkgPathMisses]) => {
+    //     pkgMemo[resolveToPosix(cwd, pkgPath)] = pkgPathMisses;
+    //     return pkgMemo;
+    //   }, {});
+    //   return memo;
+    // }, {});
 
 
-    // // TODO: Unwind misses format back to straight keys and match resolutions
-    // // TODO: May need to normalize resolutions keys
-    // // TODO: Test win32 resolutions paths
-    // console.log("TODO HERE Start Matching Misses + Resolutions", {
-    //   bundleName,
-    //   cwd,
-    //   srcs,
-    //   resSrcs,
-    //   pkgs,
-    //   resolutions
-    // });
+    // TODO: Unwind misses format back to straight keys and match resolutions
+    // TODO: May need to normalize resolutions keys
+    // TODO: Test win32 resolutions paths
+    console.log("TODO HERE Start Matching Misses + Resolutions", {
+      bundleName,
+      cwd,
+      srcs,
+      resSrcs,
+      pkgs,
+      resolutions
+    });
 
-    // return;
+    return;
 
 
     const srcsLen = Object.keys(misses.srcs).length;

--- a/index.js
+++ b/index.js
@@ -642,6 +642,8 @@ class Jetpack {
   }
 
   async packageFunction({ functionName, functionObject, worker, report }) {
+    const opts = this._extraOptions({ functionObject });
+
     // Mimic built-in serverless naming.
     // **Note**: We _do_ append ".serverless" in path skipping serverless'
     // internal copying logic.
@@ -661,8 +663,7 @@ class Jetpack {
       this._handleTraceMisses({ misses: trace.misses, bundleName });
     }
 
-    const { bail } = this._extraOptions({ functionObject }).collapsed;
-    this._handleCollapsed({ collapsed, bundleName, bail });
+    this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });
 
     // Mutate serverless configuration to use our artifacts.
     functionObject.package = functionObject.package || {};
@@ -677,6 +678,7 @@ class Jetpack {
     const { service } = this.serverless;
     const serviceName = service.service;
     const servicePackage = service.package;
+    const opts = this._serviceOptions;
 
     // Mimic built-in serverless naming.
     const bundleName = path.join(SLS_TMP_DIR, `${serviceName}.zip`);
@@ -695,8 +697,7 @@ class Jetpack {
       this._handleTraceMisses({ misses: trace.misses, bundleName });
     }
 
-    const { bail } = this._serviceOptions.collapsed;
-    this._handleCollapsed({ collapsed, bundleName, bail });
+    this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });
 
     // Mutate serverless configuration to use our artifacts.
     servicePackage.artifact = bundleName;
@@ -706,6 +707,7 @@ class Jetpack {
   }
 
   async packageLayer({ layerName, layerObject, worker, report }) {
+    const opts = this._extraOptions({ layerObject });
     const bundleName = path.join(SLS_TMP_DIR, `${layerName}.zip`);
 
     // Package. (Not traced)
@@ -713,8 +715,7 @@ class Jetpack {
     const results = await this.globAndZip({ bundleName, layerObject, worker, report });
     const { buildTime, collapsed } = results;
 
-    const { bail } = this._extraOptions({ layerObject }).collapsed;
-    this._handleCollapsed({ collapsed, bundleName, bail });
+    this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });
 
     // Mutate serverless configuration to use our artifacts.
     layerObject.package = layerObject.package || {};

--- a/index.js
+++ b/index.js
@@ -403,6 +403,10 @@ class Jetpack {
   _handleTraceMisses({ misses, bundleName, bail }) {
     const files = Object.keys(misses);
 
+    // console.log("TODO HERE _handleTraceMisses", JSON.stringify({
+    //   misses
+    // }, null, 2));
+
     // No trace misses. Yay!
     if (files.length) { return; }
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,29 @@ const dedent = (str, num) => str
 
 const uniq = (val, i, arr) => val !== arr[i - 1];
 
+// Merge two objects of form `{ key: [] }`.
+const smartMerge = (obj1, obj2) => []
+  // Get all unique missing package keys.
+  .concat(
+    Object.keys(obj1),
+    Object.keys(obj2)
+  )
+  .sort()
+  .filter(uniq)
+  // Smart merge unique missing values
+  .reduce((obj, key) => {
+    // Aggregate service and function unique missing values.
+    obj[key] = []
+      .concat(
+        obj1[key] || [],
+        obj2[key] || []
+      )
+      .sort()
+      .filter(uniq);
+
+    return obj;
+  }, {});
+
 /**
  * Package Serverless applications manually.
  *
@@ -283,27 +306,7 @@ class Jetpack {
       // Make unique.
       .sort()
       .filter(uniq);
-    functionObj.allowMissing = []
-      // Get all unique missing package keys.
-      .concat(
-        Object.keys(serviceObj.allowMissing),
-        Object.keys(functionObj.allowMissing)
-      )
-      .sort()
-      .filter(uniq)
-      // Smart merge unique missing values
-      .reduce((obj, key) => {
-        // Aggregate service and function unique missing values.
-        obj[key] = []
-          .concat(
-            serviceObj.allowMissing[key] || [],
-            functionObj.allowMissing[key] || []
-          )
-          .sort()
-          .filter(uniq);
-
-        return obj;
-      }, {});
+    functionObj.allowMissing = smartMerge(serviceObj.allowMissing, functionObj.allowMissing);
     functionObj.dynamic = {
       bail: typeof functionObj.dynamic.bail !== "undefined"
         ? functionObj.dynamic.bail

--- a/index.js
+++ b/index.js
@@ -389,20 +389,27 @@ class Jetpack {
   }
 
   _traceMissesPkgsReport(pkgMisses) {
-    return Object.entries(pkgMisses)
-      .map(([pkgName, misses]) => [`- \`${pkgName}\``].concat(
-        this._traceMissesReport(misses).map((line) => `    ${line}`)
-      ))
+    return Object.values(pkgMisses)
+      .map((misses) => this._traceMissesReport(misses))
       .reduce((arr, missList) => arr.concat(missList), []);
   }
 
   // Handle tracing misses
-  _handleTraceMisses({ misses, bundleName, bail }) {
+  _handleTraceMisses({ bundleName, misses, resolutions, bail }) {
     const srcsLen = Object.keys(misses.srcs).length;
     const pkgsLen = Object.keys(misses.pkgs).length;
 
     // No trace misses. Yay!
     if (!srcsLen && !pkgsLen) { return; }
+
+    // TODO: Unwind misses format back to straight keys and match resolutions
+    // TODO: May need to normalize resolutions keys
+    // TODO: Test win32 resolutions paths
+    console.log("TODO HERE Start Matching Misses + Resolutions", {
+      bundleName,
+      misses,
+      resolutions
+    });
 
     if (srcsLen) {
       const srcsReport = JSON.stringify(Object.keys(misses.srcs));
@@ -689,7 +696,12 @@ class Jetpack {
     });
     const { buildTime, collapsed, trace } = results;
     if (mode === "trace") {
-      this._handleTraceMisses({ misses: trace.misses, bundleName, bail: dynamic.bail });
+      this._handleTraceMisses({
+        bundleName,
+        misses: trace.misses,
+        resolutions: dynamic.resolutions,
+        bail: dynamic.bail
+      });
     }
 
     this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });
@@ -723,7 +735,12 @@ class Jetpack {
     });
     const { buildTime, collapsed, trace } = results;
     if (mode === "trace") {
-      this._handleTraceMisses({ misses: trace.misses, bundleName, bail: dynamic.bail });
+      this._handleTraceMisses({
+        bundleName,
+        misses: trace.misses,
+        resolutions: dynamic.resolutions,
+        bail: dynamic.bail
+      });
     }
 
     this._handleCollapsed({ collapsed, bundleName, bail: opts.collapsed.bail });

--- a/index.js
+++ b/index.js
@@ -36,20 +36,15 @@ const smartConcat = (arr1 = [], arr2 = []) => []
   .filter(uniq);
 
 // Merge two objects of form `{ key: [] }`.
-const smartMerge = (obj1 = {}, obj2 = {}) => []
+const smartMerge = (obj1 = {}, obj2 = {}) =>
   // Get all unique missing package keys.
-  .concat(
-    Object.keys(obj1),
-    Object.keys(obj2)
-  )
-  .sort()
-  .filter(uniq)
+  smartConcat(Object.keys(obj1), Object.keys(obj2))
   // Smart merge unique missing values
-  .reduce((obj, key) => {
+    .reduce((obj, key) => {
     // Aggregate service and function unique missing values.
-    obj[key] = smartConcat(obj1[key], obj2[key]);
-    return obj;
-  }, {});
+      obj[key] = smartConcat(obj1[key], obj2[key]);
+      return obj;
+    }, {});
 
 /**
  * Package Serverless applications manually.
@@ -274,12 +269,8 @@ class Jetpack {
       dynamic: {},
       ...typeof serviceTrace === "object" ? serviceTrace : {}
     };
-    serviceObj.include = []
-      // Aggregate with all service-packaged functions.
-      .concat(serviceObj.include, serviceFnIncludes)
-      // Make unique.
-      .sort()
-      .filter(uniq);
+    // Aggregate with all service-packaged functions.
+    serviceObj.include = smartConcat(serviceObj.include, serviceFnIncludes);
     serviceObj.dynamic = {
       bail: false,
       resolutions: {},
@@ -296,18 +287,8 @@ class Jetpack {
       dynamic: {},
       ...typeof functionTrace === "object" ? functionTrace : {}
     };
-    functionObj.include = []
-      // Aggregate in service-level includes first
-      .concat(serviceObj.include, functionObj.include)
-      // Make unique.
-      .sort()
-      .filter(uniq);
-    functionObj.ignores = []
-      // Aggregate in service-level ignores first
-      .concat(serviceObj.ignores, functionObj.ignores)
-      // Make unique.
-      .sort()
-      .filter(uniq);
+    functionObj.include = smartConcat(serviceObj.include, functionObj.include);
+    functionObj.ignores = smartConcat(serviceObj.ignores, functionObj.ignores);
     functionObj.allowMissing = smartMerge(serviceObj.allowMissing, functionObj.allowMissing);
     functionObj.dynamic = {
       bail: typeof functionObj.dynamic.bail !== "undefined"

--- a/index.js
+++ b/index.js
@@ -402,16 +402,18 @@ class Jetpack {
   // Handle tracing misses
   _handleTraceMisses({ misses, bundleName, bail }) {
     const files = Object.keys(misses);
-    if (files.length) {
-      this._logWarning(
-        `Found ${files.length} source files with tracing dynamic import misses in ${bundleName}! `
-        + "Please see logs and read: https://npm.im/serverless-jetpack#handling-dynamic-import-misses"
-      );
-      this._log(
-        `${bundleName} source files with tracing dynamic import misses: ${JSON.stringify(files)}`,
-        { color: "gray" }
-      );
-    }
+
+    // No trace misses. Yay!
+    if (files.length) { return; }
+
+    this._logWarning(
+      `Found ${files.length} source files with tracing dynamic import misses in ${bundleName}! `
+      + "Please see logs and read: https://npm.im/serverless-jetpack#handling-dynamic-import-misses"
+    );
+    this._log(
+      `${bundleName} source files with tracing dynamic import misses: ${JSON.stringify(files)}`,
+      { color: "gray" }
+    );
 
     if (bail) {
       throw new Error(

--- a/index.js
+++ b/index.js
@@ -490,10 +490,12 @@ class Jetpack {
 
       ### Trace: Configuration
 
+      \`\`\`yml
       # Ignores (\`${trace.ignores.length}\`):
       ${trace.ignores.map((p) => `- '${p}'`).join(JOIN_STR)}
       # Allowed Missing (\`${Object.keys(trace.allowMissing).length}\`):
       ${Object.keys(trace.allowMissing).map((k) => `- '${k}': ${JSON.stringify(trace.allowMissing[k])}`).join(JOIN_STR)}
+      \`\`\`
 
       ### Patterns: Include
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "make-dir": "^3.0.2",
     "nanomatch": "^1.2.13",
     "p-limit": "^2.3.0",
-    "trace-deps": "^0.3.2"
+    "trace-deps": "FormidableLabs/trace-deps#feature/resolutions"
   },
   "devDependencies": {
     "adm-zip": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "scripts": {
     "preversion": "yarn run check",
     "clean": "del-cli \"test/packages/*/*/.serverless\" .test-zips",
+    "build:toc": "doctoc --github --notitle --maxlevel 4 README.md",
+    "build": "yarn build:toc",
     "benchmark:install": "node test/script.js install",
     "benchmark:build": "node test/script.js build",
     "benchmark:test": "mocha test/benchmark.js",
@@ -54,6 +56,7 @@
     "chalk": "^4.0.0",
     "del": "^5.1.0",
     "del-cli": "^3.0.0",
+    "doctoc": "^1.4.0",
     "eslint": "^6.8.0",
     "eslint-config-formidable": "^4.0.0",
     "eslint-plugin-filenames": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "make-dir": "^3.0.2",
     "nanomatch": "^1.2.13",
     "p-limit": "^2.3.0",
-    "trace-deps": "FormidableLabs/trace-deps#feature/resolutions"
+    "trace-deps": "^0.3.3"
   },
   "devDependencies": {
     "adm-zip": "^0.4.14",

--- a/test/packages/huge-prod/npm/serverless.js
+++ b/test/packages/huge-prod/npm/serverless.js
@@ -9,6 +9,7 @@ const jetpack = () => ({
   service: {
     trace: process.env.MODE !== "trace" ? false : {
       dynamic: {
+        bail: true,
         resolutions: {
           "express/lib/view.js": []
         }

--- a/test/packages/huge-prod/npm/serverless.js
+++ b/test/packages/huge-prod/npm/serverless.js
@@ -7,7 +7,13 @@ const pkg = () => ({
 
 const jetpack = () => ({
   service: {
-    trace: process.env.MODE === "trace"
+    trace: process.env.MODE !== "trace" ? false : {
+      dynamic: {
+        resolutions: {
+          "express/lib/view.js": []
+        }
+      }
+    }
   }
 });
 

--- a/test/packages/huge-prod/yarn/serverless.js
+++ b/test/packages/huge-prod/yarn/serverless.js
@@ -7,7 +7,14 @@ const pkg = () => ({
 
 const jetpack = () => ({
   service: {
-    trace: process.env.MODE === "trace"
+    trace: process.env.MODE !== "trace" ? false : {
+      dynamic: {
+        bail: true,
+        resolutions: {
+          "express/lib/view.js": []
+        }
+      }
+    }
   }
 });
 

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -469,7 +469,7 @@ describe("index", () => {
       });
 
       describe("trace.dynamic.resolutions", () => {
-        it.skip("resolves misses at service-level", async () => {
+        it.only("resolves misses at service-level", async () => {
           mock({
             "serverless.yml": `
               service: sls-mocked
@@ -484,7 +484,7 @@ describe("index", () => {
                       resolutions:
                         # Sources (start with a dot)
                         # Resolve by ignoring (empty array)
-                        # TODO(CHECK BAIL) "./one.js": []
+                        "./one.js": false
 
                         # Resolve with a package and another application source.
                         "./lib/one-another.js":

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -469,7 +469,7 @@ describe("index", () => {
       });
 
       describe("trace.dynamic.resolutions", () => {
-        it.skip("resolves misses at service-level", async () => {
+        it.only("resolves misses at service-level", async () => {
           mock({
             "serverless.yml": `
               service: sls-mocked
@@ -480,10 +480,10 @@ describe("index", () => {
                    - "!**"
                   trace:
                     dynamic:
-                      bail: true
+                      bail: false  # TODO(trace-options): make true
                       resolutions:
                         "needs-resolutions-pkg/lib/file.js":
-                          - "added-by-resolve-trace"
+                          - "added-by-resolve-trace-pkg"
                           # TODO(trace-options): A nested path package
 
               provider:
@@ -507,6 +507,7 @@ describe("index", () => {
               // A dynamic import
               const dyn = require(process.env.DYNAMIC_IMPORT);
               require("./lib/one-another");
+              require("needs-resolutions-pkg");
 
               exports.handler = async () => ({
                 body: JSON.stringify({ one: require("one-pkg") })
@@ -543,7 +544,7 @@ describe("index", () => {
                 "package.json": stringify({
                   main: "index.js"
                 }),
-                "index.js": "module.exports = require('./nested/file.js');",
+                "index.js": "module.exports = require('./lib/file.js');",
                 lib: {
                   "file.js": "module.exports = require.resolve(process.env.DYNAMIC);"
                 }
@@ -582,6 +583,11 @@ describe("index", () => {
             .to.be.calledWithMatch({ files: [
               "one.js",
               "lib/one-another.js",
+              "node_modules/added-by-resolve-trace-pkg/index.js",
+              "node_modules/added-by-resolve-trace-pkg/package.json",
+              "node_modules/needs-resolutions-pkg/index.js",
+              "node_modules/needs-resolutions-pkg/lib/file.js",
+              "node_modules/needs-resolutions-pkg/package.json",
               "node_modules/one-pkg/index.js",
               "node_modules/one-pkg/package.json"
             ] });

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -840,7 +840,11 @@ describe("index", () => {
             "Bailing on 1 missed dynamic imports."
           );
         });
+      });
 
+      describe("trace.dynamic.resolutions", () => {
+        // TODO: HERE
+        // TODO: Also add bail in.
         it("resolves misses at service-level"); // TODO(trace-options)
 
         it("resolves misses at function-level"); // TODO(trace-options)

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -477,14 +477,14 @@ describe("index", () => {
               custom:
                 jetpack:
                   preInclude:
-                    - "!**"
+                   - "!**"
                   trace:
                     dynamic:
-                      # TODO: ENABLE BAIL
                       bail: true
                       resolutions:
-                        "needs-resolves":
-                          - "node_modules/added-by-resolve-trace/**/*.js"
+                        "needs-resolutions-pkg/lib/file.js":
+                          - "added-by-resolve-trace"
+                          # TODO(trace-options): A nested path package
 
               provider:
                 name: aws
@@ -495,12 +495,13 @@ describe("index", () => {
                 one:
                   handler: one.handler
                   jetpack:
-                    dynamic:
-                      # These resolutions should _not_ be included because
-                      # service-level packaging.
-                      resolutions:
-                        "needs-resolves":
-                          - "dont-include.js"
+                    trace:
+                      dynamic:
+                        # These resolutions should _not_ be included because
+                        # service-level packaging.
+                        resolutions:
+                          "needs-resolutions-pkg/lib/file.js":
+                            - "dont-include-pkg"
             `,
             "one.js": `
               // A dynamic import
@@ -537,6 +538,26 @@ describe("index", () => {
 
                   module.exports = "one";
                 `
+              },
+              "needs-resolutions-pkg": {
+                "package.json": stringify({
+                  main: "index.js"
+                }),
+                "index.js": "module.exports = require('./nested/file.js');",
+                lib: {
+                  "file.js": "module.exports = require.resolve(process.env.DYNAMIC);"
+                }
+              },
+              "added-by-resolve-trace-pkg": {
+                "package.json": stringify({
+                  main: "index.js"
+                }),
+                "index.js": "module.exports = 'added-by-resolve-trace';",
+                nested: {
+                  other: {
+                    "stuff.js": "module.exports = 'stuff-added-by-resolve-trace';"
+                  }
+                }
               },
               "dont-include-pkg": {
                 "package.json": stringify({

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -666,6 +666,14 @@ describe("index", () => {
           .to.be.calledWithMatch({ traceInclude: undefined }).and
           .to.not.be.calledWithMatch({ traceInclude: ["three.js"] });
       });
+
+      it("bails on misses at service-level"); // TODO(trace-options)
+
+      it("bails on misses at function-level"); // TODO(trace-options)
+
+      it("resolves misses at service-level"); // TODO(trace-options)
+
+      it("resolves misses at function-level"); // TODO(trace-options)
     });
   });
 

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -488,17 +488,19 @@ describe("index", () => {
 
                         # Resolve with a package and another application source.
                         "./lib/one-another.js":
-                          - "added-by-one-another-pkg/nested/file.js"
                           # This **adds** dep that then has a tracing miss and resolution!
                           - "./just-ignore.js"
+                          # A nested package path.
+                          - "added-by-one-another-pkg/nested/file.js"
 
-                        # Hand a path that needs normalization.
+                        # A that needs normalization. (Also ignored.)
                         "./lib/../lib/just-ignore.js": []
 
                         # Packages (no dot)
                         "needs-resolutions-pkg/lib/file.js":
                           - "added-by-resolve-trace-pkg"
-                          # TODO(trace-options): A nested path package
+
+                        "one-pkg/index.js": []
 
               provider:
                 name: aws
@@ -623,7 +625,7 @@ describe("index", () => {
               "node_modules/one-pkg/index.js",
               "node_modules/one-pkg/package.json"
             ] });
-        }); // TODO(trace-options)
+        });
 
         // TODO(trace-options): Make sure to merge in service to function level.
         it("resolves misses at function-level"); // TODO(trace-options)

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -757,9 +757,46 @@ describe("index", () => {
             .to.be.calledWithMatch({ traceInclude: ["one.js", "two.js"] });
         });
 
-        // TODO: HERE
-        it("bails on misses at service-level"); // TODO(trace-options)
+        it("bails on misses at service-level", async () => {
+          mock({
+            "serverless.yml": `
+              service: sls-mocked
 
+              custom:
+                jetpack:
+                  trace:
+                    dynamic:
+                      bail: true
+
+              provider:
+                name: aws
+                runtime: nodejs12.x
+
+              functions:
+                one:
+                  handler: one.handler
+                two:
+                  handler: two.handler
+            `,
+            "one.js": `
+              exports.handler = async () => ({
+                body: JSON.stringify({ message: "one" })
+              });
+            `,
+            "two.js": `
+              exports.handler = async () => ({
+                body: JSON.stringify({ message: "two" })
+              });
+            `
+          });
+
+          const plugin = new Jetpack(await createServerless());
+          await expect(plugin.package()).to.be.rejectedWith(
+            "Bailing on 1 missed dynamic imports."
+          );
+        });
+
+        // TODO: HERE
         it("bails on misses at function-level"); // TODO(trace-options)
 
         it("resolves misses at service-level"); // TODO(trace-options)

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -469,7 +469,7 @@ describe("index", () => {
       });
 
       describe("trace.dynamic.resolutions", () => {
-        it.only("resolves misses at service-level", async () => {
+        it.skip("resolves misses at service-level", async () => {
           mock({
             "serverless.yml": `
               service: sls-mocked
@@ -494,6 +494,13 @@ describe("index", () => {
                 # Service functions
                 one:
                   handler: one.handler
+                  jetpack:
+                    dynamic:
+                      # These resolutions should _not_ be included because
+                      # service-level packaging.
+                      resolutions:
+                        "needs-resolves":
+                          - "dont-include.js"
             `,
             "one.js": `
               // A dynamic import
@@ -517,7 +524,7 @@ describe("index", () => {
                 exports.handler = async () => ({
                   body: JSON.stringify({ one: "another" })
                 });
-              `,
+              `
             },
             node_modules: {
               "one-pkg": {

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -469,7 +469,7 @@ describe("index", () => {
       });
 
       describe("trace.dynamic.resolutions", () => {
-        it.only("resolves misses at service-level", async () => {
+        it.skip("resolves misses at service-level", async () => {
           mock({
             "serverless.yml": `
               service: sls-mocked

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -469,7 +469,7 @@ describe("index", () => {
       });
 
       describe("trace.dynamic.resolutions", () => {
-        it.only("resolves misses at service-level", async () => {
+        it("resolves misses at service-level", async () => {
           mock({
             "serverless.yml": `
               service: sls-mocked
@@ -480,7 +480,7 @@ describe("index", () => {
                    - "!**"
                   trace:
                     dynamic:
-                      bail: false  # TODO(trace-options): make true
+                      bail: true
                       resolutions:
                         # Sources (start with a dot)
                         # Resolve by ignoring (empty array)

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -477,7 +477,7 @@ describe("index", () => {
             buildTime: 0,
             collapsed: { srcs: {}, pkgs: {} },
             trace: {
-              misses: {}
+              misses: { srcs: {}, pkgs: {} }
             }
           }));
         });
@@ -677,38 +677,43 @@ describe("index", () => {
             collapsed: { srcs: {}, pkgs: {} },
             trace: {
               misses: {
-                "node_modules/@heroku/socksv5/index.js": [
-                  {
-                    start: 118,
-                    end: 150,
-                    loc: {
-                      start: {
-                        line: 5,
-                        column: 12
+                srcs: {},
+                pkgs: {
+                  "@heroku/socksv5": {
+                    "node_modules/@heroku/socksv5/index.js": [
+                      {
+                        start: 118,
+                        end: 150,
+                        loc: {
+                          start: {
+                            line: 5,
+                            column: 12
+                          },
+                          end: {
+                            line: 5,
+                            column: 44
+                          }
+                        },
+                        src: "require(__dirname + '/lib/' + f)"
                       },
-                      end: {
-                        line: 5,
-                        column: 44
+                      {
+                        start: 400,
+                        end: 437,
+                        loc: {
+                          start: {
+                            line: 14,
+                            column: 42
+                          },
+                          end: {
+                            line: 14,
+                            column: 79
+                          }
+                        },
+                        src: "require(__dirname + '/lib/auth/' + f)"
                       }
-                    },
-                    src: "require(__dirname + '/lib/' + f)"
-                  },
-                  {
-                    start: 400,
-                    end: 437,
-                    loc: {
-                      start: {
-                        line: 14,
-                        column: 42
-                      },
-                      end: {
-                        line: 14,
-                        column: 79
-                      }
-                    },
-                    src: "require(__dirname + '/lib/auth/' + f)"
+                    ]
                   }
-                ]
+                }
               }
             }
           }));
@@ -792,7 +797,7 @@ describe("index", () => {
 
           const plugin = new Jetpack(await createServerless());
           await expect(plugin.package()).to.be.rejectedWith(
-            "Bailing on 1 missed dynamic imports."
+            "Bailing on tracing dynamic import misses. Source Files: 0, Dependencies: 1"
           );
         });
 
@@ -837,7 +842,7 @@ describe("index", () => {
 
           const plugin = new Jetpack(await createServerless());
           await expect(plugin.package()).to.be.rejectedWith(
-            "Bailing on 1 missed dynamic imports."
+            "Bailing on tracing dynamic import misses. Source Files: 0, Dependencies: 1"
           );
         });
       });
@@ -859,7 +864,7 @@ describe("index", () => {
         buildTime: 0,
         collapsed: { srcs: {}, pkgs: {} },
         trace: {
-          misses: {}
+          misses: { srcs: {}, pkgs: {} }
         }
       }));
 
@@ -956,7 +961,7 @@ describe("index", () => {
             }
           },
           trace: {
-            misses: {}
+            misses: { srcs: {}, pkgs: {} }
           }
         }));
       });

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -667,7 +667,7 @@ describe("index", () => {
             "one.js": `
               // A dynamic import
               const dyn = require(process.env.DYNAMIC_IMPORT);
-              require("needs-resolutions-pkg");
+              require("parent-pkg");
 
               exports.handler = async () => ({
                 body: JSON.stringify({ one: require("one-pkg") })
@@ -682,13 +682,22 @@ describe("index", () => {
                   module.exports = "one";
                 `
               },
-              "needs-resolutions-pkg": {
+              "parent-pkg": {
                 "package.json": stringify({
                   main: "index.js"
                 }),
-                "index.js": "module.exports = require('./lib/file.js');",
-                lib: {
-                  "file.js": "module.exports = require.resolve(process.env.DYNAMIC);"
+                "index.js": "module.exports = require('needs-resolutions-pkg');",
+                node_modules: {
+                  // Different from service test, this is a nested package.
+                  "needs-resolutions-pkg": {
+                    "package.json": stringify({
+                      main: "index.js"
+                    }),
+                    "index.js": "module.exports = require('./lib/file.js');",
+                    lib: {
+                      "file.js": "module.exports = require.resolve(process.env.DYNAMIC);"
+                    }
+                  }
                 }
               },
               "added-by-resolve-trace-pkg": {
@@ -739,11 +748,13 @@ describe("index", () => {
               "node_modules/added-by-resolve-trace-pkg/package.json",
               "node_modules/also-added-by-resolve-trace-pkg/index.js",
               "node_modules/also-added-by-resolve-trace-pkg/package.json",
-              "node_modules/needs-resolutions-pkg/index.js",
-              "node_modules/needs-resolutions-pkg/lib/file.js",
-              "node_modules/needs-resolutions-pkg/package.json",
               "node_modules/one-pkg/index.js",
-              "node_modules/one-pkg/package.json"
+              "node_modules/one-pkg/package.json",
+              "node_modules/parent-pkg/index.js",
+              "node_modules/parent-pkg/node_modules/needs-resolutions-pkg/index.js",
+              "node_modules/parent-pkg/node_modules/needs-resolutions-pkg/lib/file.js",
+              "node_modules/parent-pkg/node_modules/needs-resolutions-pkg/package.json",
+              "node_modules/parent-pkg/package.json"
             ] });
         });
 

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -469,7 +469,7 @@ describe("index", () => {
       });
 
       describe("trace.dynamic.resolutions", () => {
-        it.skip("resolves misses at service-level", async () => {
+        it.only("resolves misses at service-level", async () => {
           mock({
             "serverless.yml": `
               service: sls-mocked
@@ -483,13 +483,16 @@ describe("index", () => {
                       bail: false  # TODO(trace-options): make true
                       resolutions:
                         # Sources (start with a dot)
+                        # Resolve by ignoring (empty array)
+                        # TODO(CHECK BAIL) "./one.js": []
+
+                        # Resolve with a package and another application source.
                         "./lib/one-another.js":
                           - "added-by-one-another-pkg/nested/file.js"
                           # This **adds** dep that then has a tracing miss and resolution!
                           - "./just-ignore.js"
 
                         # Hand a path that needs normalization.
-                        # Empty array value means "just ignore misses"
                         "./lib/../lib/just-ignore.js": []
 
                         # Packages (no dot)
@@ -610,6 +613,8 @@ describe("index", () => {
               "one.js",
               "lib/just-ignore.js",
               "lib/one-another.js",
+              "node_modules/added-by-one-another-pkg/nested/file.js",
+              "node_modules/added-by-one-another-pkg/package.json",
               "node_modules/added-by-resolve-trace-pkg/index.js",
               "node_modules/added-by-resolve-trace-pkg/package.json",
               "node_modules/needs-resolutions-pkg/index.js",

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -498,11 +498,12 @@ const globAndZip = async ({
     const traced = await traceFiles({ ...traceParams, srcPaths });
     traceMisses = mapTraceMisses({ traced, servicePath });
 
-    // // TODO: HERE -- Start looking at resolutions
-    // console.log("TODO HERE bundle", JSON.stringify({
-    //   srcPaths,
-    //   traceMisses
-    // }, null, 2));
+    // TODO: HERE -- Start looking at resolutions
+    console.log("TODO HERE bundle", JSON.stringify({
+      srcPaths,
+      traceParams,
+      traceMisses
+    }, null, 2));
 
     depInclude = depInclude.concat(
       // Add all handler files first.

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -529,6 +529,7 @@ const globAndZip = async ({
   let results = {
     numFiles: included.length,
     bundlePath,
+    mode: traceInclude ? "trace" : "dependency",
     buildTime: new Date() - start,
     collapsed,
     trace: {
@@ -544,7 +545,9 @@ const globAndZip = async ({
       trace: {
         ...results.trace,
         ignores: traceParams.ignores || [],
-        allowMissing: traceParams.allowMissing || {}
+        allowMissing: traceParams.allowMissing || {},
+        missed: { srcs: {}, pkgs: {} },
+        resolved: { srcs: {}, pkgs: {} }
       },
       patterns: {
         preInclude,

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -498,11 +498,11 @@ const globAndZip = async ({
     const traced = await traceFiles({ ...traceParams, srcPaths });
     traceMisses = mapTraceMisses({ traced, servicePath });
 
-    // // TODO: HERE -- Start looking at resolutions
-    // console.log("TODO HERE bundle", JSON.stringify({
-    //   srcPaths,
-    //   traceMisses
-    // }, null, 2));
+    // TODO: HERE -- Start looking at resolutions
+    console.log("TODO HERE bundle", JSON.stringify({
+      srcPaths,
+      traceMisses
+    }, null, 2));
 
     depInclude = depInclude.concat(
       // Add all handler files first.

--- a/util/bundle.js
+++ b/util/bundle.js
@@ -498,11 +498,11 @@ const globAndZip = async ({
     const traced = await traceFiles({ ...traceParams, srcPaths });
     traceMisses = mapTraceMisses({ traced, servicePath });
 
-    // TODO: HERE -- Start looking at resolutions
-    console.log("TODO HERE bundle", JSON.stringify({
-      srcPaths,
-      traceMisses
-    }, null, 2));
+    // // TODO: HERE -- Start looking at resolutions
+    // console.log("TODO HERE bundle", JSON.stringify({
+    //   srcPaths,
+    //   traceMisses
+    // }, null, 2));
 
     depInclude = depInclude.concat(
       // Add all handler files first.

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,24 @@
     request "^2.88.0"
     request-promise-native "^1.0.8"
 
+"@textlint/ast-node-types@^4.0.3":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz#ae13981bc8711c98313a6ac1c361194d6bf2d39b"
+  integrity sha512-+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==
+
+"@textlint/markdown-to-ast@~6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@textlint/markdown-to-ast/-/markdown-to-ast-6.0.9.tgz#e7c89e5ad15d17dcd8e5a62758358936827658fa"
+  integrity sha512-hfAWBvTeUGh5t5kTn2U3uP3qOSM1BSrxzl1jF3nn0ywfZXpRBZr5yRjXnl4DzIYawCtZOshmRi/tI3/x4TE1jQ==
+  dependencies:
+    "@textlint/ast-node-types" "^4.0.3"
+    debug "^2.1.3"
+    remark-frontmatter "^1.2.0"
+    remark-parse "^5.0.0"
+    structured-source "^3.0.2"
+    traverse "^0.6.6"
+    unified "^6.1.6"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -502,6 +520,13 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+anchor-markdown-header@^0.5.5:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz#045063d76e6a1f9cd327a57a0126aa0fdec371a7"
+  integrity sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=
+  dependencies:
+    emoji-regex "~6.1.0"
 
 ansi-align@^2.0.0:
   version "2.0.0"
@@ -834,6 +859,11 @@ backo2@1.0.2:
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
   integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
+bail@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
+  integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -907,6 +937,11 @@ bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+boundary@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/boundary/-/boundary-1.0.1.tgz#4d67dc2602c0cc16dd9bce7ebf87e948290f5812"
+  integrity sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -1165,6 +1200,21 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1303,6 +1353,11 @@ clone-response@1.0.2, clone-response@^1.0.2:
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
+
+collapse-white-space@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
+  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -1608,7 +1663,7 @@ debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -1936,6 +1991,18 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+doctoc@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-1.4.0.tgz#3115aa61d0a92f0abb0672036918ea904f5b9e02"
+  integrity sha512-8IAq3KdMkxhXCUF+xdZxdJxwuz8N2j25sMgqiu4U4JWluN9tRKMlAalxGASszQjlZaBprdD2YfXpL3VPWUD4eg==
+  dependencies:
+    "@textlint/markdown-to-ast" "~6.0.9"
+    anchor-markdown-header "^0.5.5"
+    htmlparser2 "~3.9.2"
+    minimist "~1.2.0"
+    underscore "~1.8.3"
+    update-section "^0.3.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1950,6 +2017,39 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-serializer@0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -2022,6 +2122,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@~6.1.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
+  integrity sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=
+
 enabled@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-1.0.2.tgz#965f6513d2c2d1c5f4652b64a2e3396467fc2f93"
@@ -2079,6 +2184,16 @@ enhanced-resolve@^4.1.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
+
+entities@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
 env-variable@0.0.x:
   version "0.0.6"
@@ -2560,6 +2675,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
@@ -2783,6 +2905,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
 formidable@^1.2.0:
   version "1.2.2"
@@ -3243,6 +3370,18 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+htmlparser2@~3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  integrity sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-cache-semantics@3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
@@ -3356,7 +3495,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3431,6 +3570,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3448,7 +3600,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -3488,6 +3640,11 @@ is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3557,6 +3714,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -3691,10 +3853,20 @@ is-url@^1.2.4:
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
+is-whitespace-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
+  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-word-character@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
+  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4210,6 +4382,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
+  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
 markdown-table@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
@@ -4348,7 +4525,7 @@ minimist@1.1.x:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
   integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -4901,6 +5078,18 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -5271,7 +5460,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5362,6 +5551,35 @@ registry-url@^5.0.0:
   dependencies:
     rc "^1.2.8"
 
+remark-frontmatter@^1.2.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz#67ec63c89da5a84bb793ecec166e11b4eb47af10"
+  integrity sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==
+  dependencies:
+    fault "^1.0.1"
+    xtend "^4.0.1"
+
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -5372,10 +5590,15 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.0.0, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 replaceall@^0.1.6:
   version "0.1.6"
@@ -6003,6 +6226,11 @@ stack-trace@0.0.x:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
+state-toggle@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
+  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -6164,6 +6392,13 @@ strip-outer@^1.0.0:
   integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
   dependencies:
     escape-string-regexp "^1.0.2"
+
+structured-source@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/structured-source/-/structured-source-3.0.2.tgz#dd802425e0f53dc4a6e7aca3752901a1ccda7af5"
+  integrity sha1-3YAkJeD1PcSm56yjdSkBoczaevU=
+  dependencies:
+    boundary "^1.0.1"
 
 stylus-lookup@^3.0.1:
   version "3.0.2"
@@ -6400,10 +6635,25 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
+  integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
 triple-beam@^1.2.0, triple-beam@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
+
+trough@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
+  integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
@@ -6479,6 +6729,31 @@ unbzip2-stream@^1.0.9:
     buffer "^5.2.1"
     through "^2.3.8"
 
+underscore@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+
+unherit@^1.0.4:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.3.tgz#6c9b503f2b41b262330c80e91c8614abdaa69c22"
+  integrity sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==
+  dependencies:
+    inherits "^2.0.0"
+    xtend "^4.0.0"
+
+unified@^6.1.6:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -6500,6 +6775,37 @@ unique-string@^1.0.0:
   integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
   dependencies:
     crypto-random-string "^1.0.0"
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
+  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -6544,6 +6850,11 @@ update-notifier@^2.5.0:
     latest-version "^3.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
+
+update-section@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
+  integrity sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=
 
 uri-js@^3.0.2:
   version "3.0.2"
@@ -6649,6 +6960,28 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
+  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 walkdir@^0.0.11:
   version "0.0.11"
@@ -6770,6 +7103,11 @@ ws@~6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
@@ -6793,7 +7131,7 @@ xmlhttprequest-ssl@~1.5.4:
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
-xtend@^4.0.0, xtend@^4.0.2:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6605,9 +6605,10 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-trace-deps@FormidableLabs/trace-deps#feature/resolutions:
-  version "0.3.2"
-  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/585654b346421160916610c3cb775cf64412b5ae"
+trace-deps@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.3.3.tgz#de04c7c81fc988355654db8e0d7cdd3b8328bc92"
+  integrity sha512-aNpC9Bd8UYuaVlo5sXSJboveHUVmeWk9/0ak/usg/eOUSt1Mj0xjLQFJ7QStBqezf0PHQi48mNTua64PS6ve7w==
   dependencies:
     acorn-node "^2.0.0"
     resolve "^1.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6605,10 +6605,9 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-trace-deps@^0.3.2:
+trace-deps@FormidableLabs/trace-deps#feature/resolutions:
   version "0.3.2"
-  resolved "https://registry.yarnpkg.com/trace-deps/-/trace-deps-0.3.2.tgz#edf81d0511412aebb806b4b4bd06668ceb530c93"
-  integrity sha512-qzfWmHT3ajGs6xLpHKhNl+UH+6xVsNFQEnVY/nWztjAYVgwkSgQmxbp3VypT67kKpCU13RO+rVce1MJladUOEg==
+  resolved "https://codeload.github.com/FormidableLabs/trace-deps/tar.gz/585654b346421160916610c3cb775cf64412b5ae"
   dependencies:
     acorn-node "^2.0.0"
     resolve "^1.15.1"


### PR DESCRIPTION
## Tasks
- [x] Finish tests, confirm TODOs gone.
- [x] Switch to published version of `trace-deps`

## Work
* Feature: Add `jetpack.trace.dynamic.bail` option. Fixes #114
* Feature: Add `jetpack.trace.dynamic.resolutions` option. Fixes #114
* Internal: Minor refactor of patterns passed for trace includes to globbing handlers. Also standardize options passed to `globby()` across different functions.
* Internal: Enhance and refactor trace miss logging as well as the `--report` format for trace misses to collapse packages.
* Docs: Add doc-toc to README