### PR TITLE
Improve bundling speed replacing inefficient reduce code

### DIFF
--- a/util/bundle.js
+++ b/util/bundle.js
@@ -51,7 +51,10 @@ const filterFiles = ({ files, preInclude, depInclude, include, exclude }) => {
 
   // Now, iterate all the patterns individually, tracking state like sls.
   // The _last_ "exclude" vs. "include" wins.
-  const filesMap = files.reduce((memo, file) => ({ ...memo, [file]: true }), []);
+  const filesMap = {};
+  files.forEach((file) => {
+    filesMap[file] = true;
+  });
   patterns.forEach((pattern) => {
     // Do a positive match, but track "keep" or "remove".
     const includeFile = !pattern.startsWith("!");


### PR DESCRIPTION
Current bundling function `filterFiles` reduces an array of file names to an object `filesMap` having those file names as properties and `true` as value to later track keep/remove status.

The problem is that the reduce operation creates a new object on each iteration and when the list of files is large enough, it stresses Node.js' memory usage and garbage collection processes to a point where it becomes very inefficient.

Instead, a much more efficient way is to just create an empty object and mutate it by adding each property as required.

For a 20,000+ files bundle, the new approach is approximate 20x faster.

All steps in "Before submitting a PR..." were followed and passed. These are the results:

## Benchmark: Timed Packages
| Scenario     | Pkg  | Type     | Mode  |  Time |      vs Base |
| :----------- | :--- | :------- | :---- | ----: | -----------: |
| simple       | yarn | jetpack  | trace |  4020 | **-72.44 %** |
| simple       | yarn | jetpack  | deps  |  3698 | **-74.64 %** |
| simple       | yarn | baseline |       | 14584 |              |
| simple       | npm  | jetpack  | trace |  5054 | **-67.97 %** |
| simple       | npm  | jetpack  | deps  |  3196 | **-79.75 %** |
| simple       | npm  | baseline |       | 15780 |              |
| complex      | yarn | jetpack  | trace |  6343 | **-73.33 %** |
| complex      | yarn | jetpack  | deps  |  5506 | **-76.85 %** |
| complex      | yarn | baseline |       | 23785 |              |
| complex      | npm  | jetpack  | trace |  7202 | **-72.07 %** |
| complex      | npm  | jetpack  | deps  |  4748 | **-81.59 %** |
| complex      | npm  | baseline |       | 25790 |              |
| individually | yarn | jetpack  | trace | 11651 | **-41.37 %** |
| individually | yarn | jetpack  | deps  | 11390 | **-42.68 %** |
| individually | yarn | baseline |       | 19872 |              |
| individually | npm  | jetpack  | trace | 14223 | **-26.31 %** |
| individually | npm  | jetpack  | deps  | 10555 | **-45.31 %** |
| individually | npm  | baseline |       | 19301 |              |
| huge         | yarn | jetpack  | trace |  4912 | **-87.38 %** |
| huge         | yarn | jetpack  | deps  |  3794 | **-90.25 %** |
| huge         | yarn | baseline |       | 38918 |              |
| huge         | npm  | jetpack  | trace |  5836 | **-85.95 %** |
| huge         | npm  | jetpack  | deps  |  3126 | **-92.47 %** |
| huge         | npm  | baseline |       | 41525 |              |
| huge-prod    | yarn | jetpack  | trace |  5087 | **-74.16 %** |
| huge-prod    | yarn | jetpack  | deps  |  6666 | **-66.15 %** |
| huge-prod    | yarn | baseline |       | 19690 |              |
| huge-prod    | npm  | jetpack  | trace |  5455 | **-74.01 %** |
| huge-prod    | npm  | jetpack  | deps  |  7175 | **-65.82 %** |
| huge-prod    | npm  | baseline |       | 20991 |              |

## Benchmark: Other Packages
| Scenario | Pkg  | Type     | Mode  | Time |      vs Base |
| :------- | :--- | :------- | :---- | ---: | -----------: |
| monorepo | yarn | jetpack  | trace | 5698 |              |
| monorepo | yarn | jetpack  | deps  | 3212 |              |
| monorepo | npm  | jetpack  | trace | 5425 |              |
| monorepo | npm  | jetpack  | deps  | 3041 |              |
| webpack  | yarn | jetpack  | trace | 4750 |  **37.40 %** |
| webpack  | yarn | jetpack  | deps  | 3179 |  **-8.04 %** |
| webpack  | yarn | baseline |       | 3457 |              |
| webpack  | npm  | jetpack  | trace | 5547 |  **49.15 %** |
| webpack  | npm  | jetpack  | deps  | 3041 | **-18.23 %** |
| webpack  | npm  | baseline |       | 3719 |              |

The improvements are significant on larger projects. Let me know if you think updating the README.md should be part of this PR too.

PS: Thanks for this package!!