### PR TITLE
Define types of jetpack options

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,11 +94,13 @@ class Jetpack {
             options: {
               "function": {
                 usage: "Function name. Packages a single function (see 'deploy function')",
-                shortcut: "f"
+                shortcut: "f",
+                type: "string"
               },
               report: {
                 usage: "Generate full bundle report",
-                shortcut: "r"
+                shortcut: "r",
+                type: "boolean"
               }
             }
           }


### PR DESCRIPTION
serverless v3 will require plugins to define types for their options
https://www.serverless.com/framework/docs/deprecations#cli-options-extensions-type-requirement