### PR TITLE
Minor: Serverless options without types are now deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,11 +94,13 @@ class Jetpack {
             options: {
               "function": {
                 usage: "Function name. Packages a single function (see 'deploy function')",
-                shortcut: "f"
+                shortcut: "f",
+                type: "string"
               },
               report: {
                 usage: "Generate full bundle report",
-                shortcut: "r"
+                shortcut: "r",
+                type: "boolean"
               }
             }
           }


### PR DESCRIPTION
Serverless plugin options without types are now deprecated and will throw warnings. 

CLI schema validation was added in 2.32 as far as I can tell from commit history, so this should not affect anyone using a lower version of serverless.

- This warning was added in Serverless 2.33
- These will throw errors in Serverless 3.x

> Serverless: Deprecation warning: CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:    
             - Jetpack for "function", "report"
            Please report this issue in plugin issue tracker.
            Starting with next major release, this will be communicated with a thrown error.
            More Info: https://www.serverless.com/framework/docs/deprecations/#CLI_OPTIONS_SCHEMA