### PR TITLE
workflow testing fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Testing Setups
+        run: yarn benchmark:ci
+
       - name: Unit Tests
         run: yarn test:cli
 


### PR DESCRIPTION
Added `yarn benchmark:ci` to get release workflow working again for tests